### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A comprehensive Model Context Protocol (MCP) server that enables seamless interaction with Excalidraw diagrams and drawings. This server provides LLMs (Large Language Models) with the ability to create, modify, query, and manipulate Excalidraw drawings through a structured, developer-friendly API.
 
+<a href="https://glama.ai/mcp/servers/@yctimlin/mcp_excalidraw">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yctimlin/mcp_excalidraw/badge" alt="Excalidraw Server MCP server" />
+</a>
+
 ## Quick Start
 
 You can run the Excalidraw MCP server directly using npx without installing anything:
@@ -277,4 +281,4 @@ Start the development server:
 
 ```bash
 npm run dev
-``` 
+```


### PR DESCRIPTION
This PR adds a badge for the [Excalidraw MCP Server](https://glama.ai/mcp/servers/@yctimlin/mcp_excalidraw) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@yctimlin/mcp_excalidraw">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yctimlin/mcp_excalidraw/badge" alt="Excalidraw Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.