### PR TITLE
feat: add configuration option for log file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ For VS Code MCP extension, add to your settings:
 |----------|---------|-------------|
 | `EXPRESS_SERVER_URL` | `http://localhost:3000` | Canvas server URL for MCP sync |
 | `ENABLE_CANVAS_SYNC` | `true` | Enable/disable canvas synchronization |
+| `LOG_FILE_PATH` | `excalidraw.log` | Path to the log file |
 | `DEBUG` | `false` | Enable debug logging |
 | `PORT` | `3000` | Canvas server port |
 | `HOST` | `localhost` | Canvas server host |

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,7 @@
 import winston from 'winston';
 
+const LOG_FILE_PATH = process.env.LOG_FILE_PATH || 'excalidraw.log';
+
 const logger: winston.Logger = winston.createLogger({
   level: process.env.LOG_LEVEL || 'info',
 
@@ -18,7 +20,7 @@ const logger: winston.Logger = winston.createLogger({
     }),
 
     new winston.transports.File({
-      filename: 'excalidraw.log',    // all levels to file
+      filename: LOG_FILE_PATH,    // all levels to file
       level: 'debug'
     })
   ]


### PR DESCRIPTION
The log file location is currently hardcoded to `excalidraw.log`.  This may not always be desired behavior, as the log may be created in a source project directory. This pull request enables an optional environment variable to override the default.