### PR TITLE
Fix: Batch endpoint now respects element IDs from MCP server

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -365,7 +365,8 @@ app.post('/api/elements/batch', (req: Request, res: Response) => {
     
     elementsToCreate.forEach(elementData => {
       const params = CreateElementSchema.parse(elementData);
-      const id = generateId();
+      // Prioritize passed ID (for MCP sync), otherwise generate new ID
+      const id = params.id || generateId();
       const element: ServerElement = {
         id,
         ...params,
@@ -373,7 +374,7 @@ app.post('/api/elements/batch', (req: Request, res: Response) => {
         updatedAt: new Date().toISOString(),
         version: 1
       };
-      
+
       elements.set(id, element);
       createdElements.push(element);
     });


### PR DESCRIPTION
## Problem

The batch creation endpoint (`/api/elements/batch`) was always generating new IDs for elements, even when IDs were passed from the MCP server. This caused a critical sync issue:

1. MCP server creates elements with specific IDs
2. MCP server sends these elements to canvas via batch endpoint
3. Canvas generates **different** IDs and stores those
4. MCP server thinks sync succeeded with its IDs
5. Canvas has completely different IDs
6. **Result**: MCP tools report "✅ Synced to canvas" but elements don't appear

## Root Cause

In `src/server.ts`:

**Single element endpoint** (line 162):
```typescript
const id = params.id || generateId(); // ✅ Respects passed ID
```

**Batch endpoint** (line 368 - before fix):
```typescript
const id = generateId(); // ❌ ALWAYS generates new ID
```

The inconsistency between these two endpoints caused the sync failure.

## Solution

Made the batch endpoint behave identically to the single element endpoint:

```typescript
// Prioritize passed ID (for MCP sync), otherwise generate new ID
const id = params.id || generateId();
```

This ensures that when the MCP server sends elements with IDs, those IDs are preserved in the canvas storage, maintaining sync integrity.

## Impact

- ✅ Fixes the "MCP tool registration issues" mentioned in the Development Roadmap
- ✅ Enables proper batch creation from MCP tools
- ✅ Elements created via `batch_create_elements` now appear on canvas
- ✅ Maintains backward compatibility (generates IDs when not provided)
- ✅ No breaking changes to API

## Testing

Tested with Claude Code MCP integration:
- Created 19-element diagram using `batch_create_elements`
- All elements now sync correctly to canvas
- Element IDs match between MCP server and canvas
- WebSocket broadcasts work as expected

## Files Changed

- `src/server.ts`: Added ID prioritization logic to batch endpoint (3 lines changed)

This is a minimal, focused fix that resolves the core sync issue without introducing unnecessary complexity.