### PR TITLE
feat(server): add bbox filter for query_elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,6 @@ public/dist/
 # Development artifacts
 *.excalidraw
 
+.DS_Store
+
 docs/

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,7 +263,13 @@ const DistributeElementsSchema = z.object({
 
 const QuerySchema = z.object({
   type: z.enum(Object.values(EXCALIDRAW_ELEMENT_TYPES) as [ExcalidrawElementType, ...ExcalidrawElementType[]]).optional(),
-  filter: z.record(z.any()).optional()
+  filter: z.record(z.any()).optional(),
+  bbox: z.object({
+    x_min: z.number().optional(),
+    x_max: z.number().optional(),
+    y_min: z.number().optional(),
+    y_max: z.number().optional()
+  }).optional()
 });
 
 const ResourceSchema = z.object({
@@ -442,13 +448,23 @@ const tools: Tool[] = [
     inputSchema: {
       type: 'object',
       properties: {
-        type: { 
-          type: 'string', 
-          enum: Object.values(EXCALIDRAW_ELEMENT_TYPES) 
+        type: {
+          type: 'string',
+          enum: Object.values(EXCALIDRAW_ELEMENT_TYPES)
         },
-        filter: { 
+        filter: {
           type: 'object',
           additionalProperties: true
+        },
+        bbox: {
+          type: 'object',
+          description: 'Bounding box filter — only return elements whose origin (x, y) falls within the given coordinate range',
+          properties: {
+            x_min: { type: 'number' },
+            x_max: { type: 'number' },
+            y_min: { type: 'number' },
+            y_max: { type: 'number' }
+          }
         }
       }
     }
@@ -982,8 +998,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
       
       case 'query_elements': {
         const params = QuerySchema.parse(args || {});
-        const { type, filter } = params;
-        
+        const { type, filter, bbox } = params;
+
         try {
           // Build query parameters
           const queryParams = new URLSearchParams();
@@ -992,6 +1008,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             Object.entries(filter).forEach(([key, value]) => {
               queryParams.set(key, String(value));
             });
+          }
+          if (bbox) {
+            if (bbox.x_min !== undefined) queryParams.set('x_min', String(bbox.x_min));
+            if (bbox.x_max !== undefined) queryParams.set('x_max', String(bbox.x_max));
+            if (bbox.y_min !== undefined) queryParams.set('y_min', String(bbox.y_min));
+            if (bbox.y_max !== undefined) queryParams.set('y_max', String(bbox.y_max));
           }
           
           // Query elements from HTTP server

--- a/src/server.ts
+++ b/src/server.ts
@@ -443,10 +443,19 @@ app.get('/api/elements/search', (req: Request, res: Response) => {
     }
 
     // Filter by bounding box if specified
-    if (x_min !== undefined) results = results.filter(el => (el as any).x >= Number(x_min));
-    if (x_max !== undefined) results = results.filter(el => (el as any).x <= Number(x_max));
-    if (y_min !== undefined) results = results.filter(el => (el as any).y >= Number(y_min));
-    if (y_max !== undefined) results = results.filter(el => (el as any).y <= Number(y_max));
+    if (x_min !== undefined || x_max !== undefined || y_min !== undefined || y_max !== undefined) {
+      const xMin = x_min !== undefined ? Number(x_min) : -Infinity;
+      const xMax = x_max !== undefined ? Number(x_max) : Infinity;
+      const yMin = y_min !== undefined ? Number(y_min) : -Infinity;
+      const yMax = y_max !== undefined ? Number(y_max) : Infinity;
+
+      results = results.filter(el =>
+        el.x >= xMin &&
+        el.x <= xMax &&
+        el.y >= yMin &&
+        el.y <= yMax
+      );
+    }
 
     // Apply additional exact-match filters
     if (Object.keys(filters).length > 0) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -434,7 +434,7 @@ app.delete('/api/elements/:id', (req: Request, res: Response) => {
 // Query elements with filters
 app.get('/api/elements/search', (req: Request, res: Response) => {
   try {
-    const { type, ...filters } = req.query;
+    const { type, x_min, x_max, y_min, y_max, ...filters } = req.query;
     let results = Array.from(elements.values());
 
     // Filter by type if specified
@@ -442,7 +442,13 @@ app.get('/api/elements/search', (req: Request, res: Response) => {
       results = results.filter(element => element.type === type);
     }
 
-    // Apply additional filters
+    // Filter by bounding box if specified
+    if (x_min !== undefined) results = results.filter(el => (el as any).x >= Number(x_min));
+    if (x_max !== undefined) results = results.filter(el => (el as any).x <= Number(x_max));
+    if (y_min !== undefined) results = results.filter(el => (el as any).y >= Number(y_min));
+    if (y_max !== undefined) results = results.filter(el => (el as any).y <= Number(y_max));
+
+    // Apply additional exact-match filters
     if (Object.keys(filters).length > 0) {
       results = results.filter(element => {
         return Object.entries(filters).every(([key, value]) => {


### PR DESCRIPTION
## Summary

- Adds `bbox` parameter to `query_elements` MCP tool with `x_min`, `x_max`, `y_min`, `y_max` fields
- Implements range filtering in `GET /api/elements/search` on the canvas server
- Elements are filtered by origin (`x`, `y`) falling within the bounding box

## Motivation

On shared canvases with multiple diagrams, `query_elements` previously returned all elements regardless of location. For a canvas  with 250+ elements across 3 separate diagrams, an agent working on one diagram had to load and discard the other 200+ elements on  every query — wasting tokens and context.

With bbox filtering, agents can scope queries to their region of the canvas, making multi-agent canvas workflows significantly  cheaper.

## Example

```json
{ "bbox": { "x_min": 100, "x_max": 750, "y_min": 680, "y_max": 1050 } }

Returns only elements in that region instead of the full scene.
```