### PR TITLE
fix: detect direct run via realpath so symlinked clones still start the server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2269,8 +2269,15 @@ if (process.env.DEBUG === 'true') {
   logger.debug('Debug mode enabled');
 }
 
-// Start the server if this file is run directly
-if (fileURLToPath(import.meta.url) === process.argv[1]) {
+// Start the server if this file is run directly. realpath both sides so a
+// symlinked clone still matches: import.meta.url is canonicalized but
+// process.argv[1] keeps the literal launcher path, so === silently fails
+// and the script exits 0 before runServer() is ever called.
+const entryPath = fileURLToPath(import.meta.url);
+const argvPath = process.argv[1];
+const isDirectRun = entryPath === argvPath ||
+  (argvPath && fs.realpathSync(entryPath) === fs.realpathSync(argvPath));
+if (isDirectRun) {
   runServer().catch(error => {
     logger.error('Failed to start server:', error);
     process.exit(1);


### PR DESCRIPTION
## Summary

When the package is launched through a path that traverses a symlink, the entry-point check at the bottom of `src/index.ts` silently fails and `runServer()` is never called. The process exits 0 within ~150 ms, which surfaces in MCP clients as `Connection closed` on every single launch.

### Root cause

Node canonicalizes `import.meta.url` to the real path, but `process.argv[1]` keeps the literal launcher path:

```
fileURLToPath(import.meta.url) = /real/path/to/dist/index.js
process.argv[1]                = /symlink/path/to/dist/index.js
```

The current check uses strict `===`, so they never match through a symlink.

This is easy to hit in practice — e.g. a clone living under `~/code/upstream/mcp_excalidraw` exposed via `~/dev/mcp_excalidraw -> code/upstream/mcp_excalidraw` for ergonomic launcher config. Every MCP attempt fails the same way (~150 ms, `MCP error -32000: Connection closed`), and because nothing reaches `logger.info('Starting Excalidraw MCP server...')`, the failure leaves no trace in `excalidraw.log`.

### Fix

Compare paths after `realpathSync` as a fallback, preserving the fast `===` path for the common non-symlinked case:

```ts
const entryPath = fileURLToPath(import.meta.url);
const argvPath = process.argv[1];
const isDirectRun = entryPath === argvPath ||
  (argvPath && fs.realpathSync(entryPath) === fs.realpathSync(argvPath));
if (isDirectRun) {
  runServer().catch(...);
}
```

## Test plan

- [x] Reproduce: launch `node /symlink/path/dist/index.js` from an MCP client → `Connection closed` after ~150 ms, no log output.
- [x] With patch applied + `npm run build:server`: same launch path → full JSON-RPC `initialize` response with all tools listed; transport stays connected until stdin closes.
- [x] Non-symlinked direct launch still triggers `runServer` via the fast `===` path (no behavior change).