### PR TITLE
Fix symlinked bin startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-excalidraw-server",
-  "version": "1.0.2",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-excalidraw-server",
-      "version": "1.0.2",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-excalidraw-server",
-  "version": "1.0.2",
+  "version": "1.0.7",
   "description": "Advanced MCP server for Excalidraw with real-time canvas, WebSocket sync, and comprehensive diagram management",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2291,8 +2291,36 @@ if (process.env.DEBUG === 'true') {
   logger.debug('Debug mode enabled');
 }
 
-// Start the server if this file is run directly
-if (fileURLToPath(import.meta.url) === process.argv[1]) {
+function getErrorCode(error: unknown): string | undefined {
+  if (typeof error === 'object' && error !== null && 'code' in error) {
+    const code = (error as { code?: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
+  }
+
+  return undefined;
+}
+
+function resolveEntrypointPath(filePath: string | undefined): string | null {
+  if (!filePath) return null;
+
+  try {
+    return fs.realpathSync(filePath);
+  } catch (error) {
+    const code = getErrorCode(error);
+    if (code !== 'ENOENT') {
+      logger.warn(`fs.realpathSync failed for "${filePath}", falling back to path.resolve.`, {
+        code,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+    return path.resolve(filePath);
+  }
+}
+
+// Start the server if this file is run directly.
+// npm/npx commonly invoke package bins through symlinks; compare real paths so
+// the stdio transport still starts from those standard install paths.
+if (resolveEntrypointPath(fileURLToPath(import.meta.url)) === resolveEntrypointPath(process.argv[1])) {
   runServer().catch(error => {
     logger.error('Failed to start server:', error);
     process.exit(1);


### PR DESCRIPTION
## Summary

Fix the MCP server startup guard so package bin invocations through npm/npx symlinks still call `runServer()`.

## Root Cause

The direct-run check compared `fileURLToPath(import.meta.url)` directly with `process.argv[1]`. On macOS, npm/npx/global package bins commonly invoke `dist/index.js` through a symlink, so `process.argv[1]` can be the symlink path while `import.meta.url` resolves to the real path. The comparison fails and the stdio transport never starts.

## Changes

- Resolve both entrypoint paths with `fs.realpathSync()` before comparing them.
- Keep a `path.resolve()` fallback if a path cannot be resolved.
- Bump package version to `1.0.7` for the follow-up npm release.

Fixes #65.

## Verification

- `npm run type-check`
- `npm run build:server`
- Symlinked `dist/index.js` probe responded to MCP `initialize` over stdio.
- Dynamic import of `dist/index.js` still returns the default `runServer` export without auto-starting.