### PR TITLE
fix(logger): platform-aware default log path instead of CWD

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,36 @@
 import winston from 'winston';
+import * as path from 'path';
+import * as fs from 'fs';
+import { homedir } from 'os';
 
-const LOG_FILE_PATH = process.env.LOG_FILE_PATH || 'excalidraw.log';
+/**
+ * Wählt einen plattformkompatiblen Default-Log-Pfad. MCP-Server werden im
+ * Arbeitsverzeichnis ihres Aufrufers gestartet — ein relativer Pfad würde
+ * dazu führen, dass Log-Dateien in fremden Projekt-/Cloud-Ordnern landen.
+ *
+ * Override via Env-Var LOG_FILE_PATH bleibt möglich.
+ */
+function defaultLogPath(): string {
+  if (process.platform === 'darwin') {
+    return path.join(homedir(), 'Library', 'Logs', 'excalidraw-mcp.log');
+  }
+  if (process.platform === 'win32') {
+    const base = process.env.LOCALAPPDATA || path.join(homedir(), 'AppData', 'Local');
+    return path.join(base, 'Excalidraw-MCP', 'excalidraw.log');
+  }
+  // Linux + andere POSIX: XDG-Konvention
+  const xdgState = process.env.XDG_STATE_HOME || path.join(homedir(), '.local', 'state');
+  return path.join(xdgState, 'excalidraw-mcp', 'excalidraw.log');
+}
+
+const LOG_FILE_PATH = process.env.LOG_FILE_PATH || defaultLogPath();
+
+// Sicherstellen, dass das Log-Verzeichnis existiert — Winston wirft sonst beim Start.
+try {
+  fs.mkdirSync(path.dirname(LOG_FILE_PATH), { recursive: true });
+} catch {
+  // Wenn das fehlschlägt, fällt der File-Transport auf Default-Behavior zurück.
+}
 
 const logger: winston.Logger = winston.createLogger({
   level: process.env.LOG_LEVEL || 'info',


### PR DESCRIPTION
## Problem

The current default `LOG_FILE_PATH = 'excalidraw.log'` is a CWD-relative path.
This is problematic for MCP servers, which are launched as stdio children of
their MCP client (Claude Desktop, Claude Code, Cursor, etc.). The child's
working directory is **the client's workspace** — not the server's install
directory.

In practice, `excalidraw.log` files get scattered across every project folder
the user touches:

- Project repos (where they may accidentally get `git add`-ed)
- Cloud-synced directories (OneDrive, iCloud Drive, Dropbox) where they cause
  sync churn
- `~/Library/Services/` and similar system directories
- Anywhere `claude-code` was previously run from

At my organization (~10 users on `mcp_excalidraw`) we ended up with `excalidraw.log`
files in 12+ OneDrive folders before tracing it back to this default.

## Fix

Pick a platform-appropriate default log location, following standard OS
conventions:

| Platform | Default Path |
|---|---|
| macOS | `~/Library/Logs/excalidraw-mcp.log` |
| Windows | `%LOCALAPPDATA%\Excalidraw-MCP\excalidraw.log` |
| Linux (XDG) | `$XDG_STATE_HOME/excalidraw-mcp/excalidraw.log` (fallback `~/.local/state/excalidraw-mcp/excalidraw.log`) |

The `LOG_FILE_PATH` env var still overrides the default, so users with custom
log-aggregation setups (e.g., centralized log forwarders) are unaffected.

The log directory is created via `fs.mkdirSync({ recursive: true })` on
startup, because Winston throws if the directory doesn't exist on first run.

## Testing

Locally verified on macOS:

1. Removed all stale `excalidraw.log` from CWD-spawning locations
2. Restarted the canvas server via launchd
3. Confirmed new logs appear in `~/Library/Logs/excalidraw-mcp.log` only

No changes to log format, log level, or log content — purely the default path
resolution.

## Backwards Compatibility

- Existing users with `LOG_FILE_PATH` env var set: no change.
- Existing users relying on default: new logs go to the platform location.
  Old `excalidraw.log` files in CWD remain (need manual cleanup, but no longer
  grow).