### PR TITLE
fix(logger): platform-aware log path with render hardening

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -146,6 +146,10 @@ const isImageElement = (element: Partial<ExcalidrawElement>): boolean => {
   return element.type === 'image'
 }
 
+const isFreedrawElement = (element: Partial<ExcalidrawElement>): boolean => {
+  return element.type === 'freedraw'
+}
+
 const isShapeContainerType = (type: string | undefined): boolean => {
   return type === 'rectangle' || type === 'ellipse' || type === 'diamond'
 }
@@ -216,6 +220,33 @@ const normalizeImageElement = (element: Partial<ExcalidrawElement>): Partial<Exc
   }
 }
 
+const normalizeFreedrawElement = (element: Partial<ExcalidrawElement>): Partial<ExcalidrawElement> => {
+  const freedraw = element as any
+  return {
+    ...freedraw,
+    angle: freedraw.angle || 0,
+    backgroundColor: freedraw.backgroundColor || 'transparent',
+    fillStyle: freedraw.fillStyle || 'solid',
+    strokeWidth: freedraw.strokeWidth || 1,
+    strokeStyle: freedraw.strokeStyle || 'solid',
+    roughness: freedraw.roughness ?? 1,
+    opacity: freedraw.opacity ?? 100,
+    groupIds: freedraw.groupIds || [],
+    roundness: null,
+    seed: freedraw.seed || Math.floor(Math.random() * 1000000),
+    version: freedraw.version || 1,
+    versionNonce: freedraw.versionNonce || Math.floor(Math.random() * 1000000),
+    isDeleted: freedraw.isDeleted ?? false,
+    boundElements: freedraw.boundElements || null,
+    link: freedraw.link || null,
+    locked: freedraw.locked || false,
+    points: freedraw.points || [],
+    pressures: freedraw.pressures || [],
+    simulatePressure: freedraw.simulatePressure ?? true,
+    lastCommittedPoint: freedraw.lastCommittedPoint || null,
+  }
+}
+
 // Helper: restore startBinding/endBinding/boundElements after convertToExcalidrawElements strips them
 const restoreBindings = (
   convertedElements: readonly any[],
@@ -256,12 +287,13 @@ const convertElementsPreservingImageProps = (
 
   const validatedElements = validateAndFixBindings(elements)
   const imageElements = validatedElements.filter(isImageElement).map(normalizeImageElement)
-  const nonImageElements = validatedElements.filter(el => !isImageElement(el))
+  const freedrawElements = validatedElements.filter(isFreedrawElement).map(normalizeFreedrawElement)
+  const nonImageElements = validatedElements.filter(el => !isImageElement(el) && !isFreedrawElement(el))
   // convertToExcalidrawElements may expand labeled shapes into [shape, textElement],
   // so we cannot assume a 1:1 mapping — return all converted elements directly.
   const convertedNonImageElements = convertToExcalidrawElements(nonImageElements as any, { regenerateIds: false })
   const restoredNonImageElements = restoreBindings(convertedNonImageElements, nonImageElements)
-  return recenterBoundShapeTextElements([...restoredNonImageElements, ...imageElements])
+  return recenterBoundShapeTextElements([...restoredNonImageElements, ...imageElements, ...freedrawElements])
 }
 
 function App(): JSX.Element {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,14 +1,14 @@
 import winston from 'winston';
 import * as path from 'path';
 import * as fs from 'fs';
-import { homedir } from 'os';
+import { homedir, tmpdir } from 'os';
 
 /**
- * Wählt einen plattformkompatiblen Default-Log-Pfad. MCP-Server werden im
- * Arbeitsverzeichnis ihres Aufrufers gestartet — ein relativer Pfad würde
- * dazu führen, dass Log-Dateien in fremden Projekt-/Cloud-Ordnern landen.
+ * Choose a platform-compatible default log path. MCP servers are launched in
+ * the caller's working directory, so a relative path would scatter log files
+ * across unrelated project and cloud-synced folders.
  *
- * Override via Env-Var LOG_FILE_PATH bleibt möglich.
+ * LOG_FILE_PATH can still override this default.
  */
 function defaultLogPath(): string {
   if (process.platform === 'darwin') {
@@ -18,19 +18,33 @@ function defaultLogPath(): string {
     const base = process.env.LOCALAPPDATA || path.join(homedir(), 'AppData', 'Local');
     return path.join(base, 'Excalidraw-MCP', 'excalidraw.log');
   }
-  // Linux + andere POSIX: XDG-Konvention
+  // Linux and other POSIX platforms: follow the XDG state convention.
   const xdgState = process.env.XDG_STATE_HOME || path.join(homedir(), '.local', 'state');
   return path.join(xdgState, 'excalidraw-mcp', 'excalidraw.log');
 }
 
 const LOG_FILE_PATH = process.env.LOG_FILE_PATH || defaultLogPath();
 
-// Sicherstellen, dass das Log-Verzeichnis existiert — Winston wirft sonst beim Start.
-try {
-  fs.mkdirSync(path.dirname(LOG_FILE_PATH), { recursive: true });
-} catch {
-  // Wenn das fehlschlägt, fällt der File-Transport auf Default-Behavior zurück.
+function ensureWritableLogFile(filePath: string): string {
+  const logDir = path.dirname(filePath);
+  fs.mkdirSync(logDir, { recursive: true });
+  fs.accessSync(logDir, fs.constants.W_OK);
+  return filePath;
 }
+
+function resolveLogFilePath(): string {
+  try {
+    return ensureWritableLogFile(LOG_FILE_PATH);
+  } catch (error) {
+    if (process.env.LOG_FILE_PATH) {
+      throw error;
+    }
+  }
+
+  return ensureWritableLogFile(path.join(tmpdir(), 'excalidraw-mcp.log'));
+}
+
+const RESOLVED_LOG_FILE_PATH = resolveLogFilePath();
 
 const logger: winston.Logger = winston.createLogger({
   level: process.env.LOG_LEVEL || 'info',
@@ -54,7 +68,7 @@ const logger: winston.Logger = winston.createLogger({
     }),
 
     new winston.transports.File({
-      filename: LOG_FILE_PATH,    // all levels to file
+      filename: RESOLVED_LOG_FILE_PATH,    // all levels to file
       level: 'debug'
     })
   ]

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,36 @@
 import winston from 'winston';
+import * as path from 'path';
+import * as fs from 'fs';
+import { homedir } from 'os';
 
-const LOG_FILE_PATH = process.env.LOG_FILE_PATH || 'excalidraw.log';
+/**
+ * Wählt einen plattformkompatiblen Default-Log-Pfad. MCP-Server werden im
+ * Arbeitsverzeichnis ihres Aufrufers gestartet — ein relativer Pfad würde
+ * dazu führen, dass Log-Dateien in fremden Projekt-/Cloud-Ordnern landen.
+ *
+ * Override via Env-Var LOG_FILE_PATH bleibt möglich.
+ */
+function defaultLogPath(): string {
+  if (process.platform === 'darwin') {
+    return path.join(homedir(), 'Library', 'Logs', 'excalidraw-mcp.log');
+  }
+  if (process.platform === 'win32') {
+    const base = process.env.LOCALAPPDATA || path.join(homedir(), 'AppData', 'Local');
+    return path.join(base, 'Excalidraw-MCP', 'excalidraw.log');
+  }
+  // Linux + andere POSIX: XDG-Konvention
+  const xdgState = process.env.XDG_STATE_HOME || path.join(homedir(), '.local', 'state');
+  return path.join(xdgState, 'excalidraw-mcp', 'excalidraw.log');
+}
+
+const LOG_FILE_PATH = process.env.LOG_FILE_PATH || defaultLogPath();
+
+// Sicherstellen, dass das Log-Verzeichnis existiert — Winston wirft sonst beim Start.
+try {
+  fs.mkdirSync(path.dirname(LOG_FILE_PATH), { recursive: true });
+} catch {
+  // Wenn das fehlschlägt, fällt der File-Transport auf Default-Behavior zurück.
+}
 
 const logger: winston.Logger = winston.createLogger({
   level: process.env.LOG_LEVEL || 'info',


### PR DESCRIPTION
Supersedes #82 because GitHub denied pushing maintainer edits back to the contributor fork.\n\nIncludes the original platform-aware logger change from #82 plus follow-up fixes from review:\n- fall back to a temp log file when the default platform log directory is unwritable, while preserving strict behavior for explicit LOG_FILE_PATH\n- preserve freedraw elements in the frontend conversion path so MCP/imported scenes render all supported element types\n\nVerified locally:\n- npm run type-check\n- npm run build\n- Browser visual E2E on local canvas with rectangle, ellipse, diamond, arrow, line, text, freedraw, and image rendered