### PR TITLE
Fix dark mode on the canvas frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,7 +11,13 @@
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
             background-color: #f5f5f5;
         }
-        
+
+        .app {
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+        }
+
         .header {
             background: #fff;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
@@ -102,7 +108,8 @@
         }
         
         .canvas-container {
-            height: calc(100vh - 80px);
+            flex: 1;
+            min-height: 0;
             width: 100%;
             position: relative;
         }
@@ -274,6 +281,42 @@
 
         .sync-time {
             color: #666;
+        }
+
+        .app[data-theme="dark"] {
+            background-color: #121212;
+            color: #e3e3e8;
+        }
+
+        .app[data-theme="dark"] .header {
+            background: #232329;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+        }
+
+        .app[data-theme="dark"] .header h1 {
+            color: #e3e3e8;
+        }
+
+        .app[data-theme="dark"] .element-count,
+        .app[data-theme="dark"] .sync-time {
+            color: #9a9aa5;
+        }
+
+        .app[data-theme="dark"] .api-panel {
+            background: #232329;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+        }
+
+        .app[data-theme="dark"] .api-panel h3,
+        .app[data-theme="dark"] label {
+            color: #e3e3e8;
+        }
+
+        .app[data-theme="dark"] input,
+        .app[data-theme="dark"] select {
+            background-color: #1a1a1e;
+            border-color: #3a3a42;
+            color: #e3e3e8;
         }
     </style>
 </head>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -306,6 +306,13 @@ function App(): JSX.Element {
   const [isConnected, setIsConnected] = useState<boolean>(false)
   const websocketRef = useRef<WebSocket | null>(null)
 
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window === 'undefined') return 'light'
+    const saved = window.localStorage?.getItem('excalidraw-canvas-theme')
+    if (saved === 'light' || saved === 'dark') return saved
+    return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  })
+
   // Sync state management
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle')
   const [lastSyncTime, setLastSyncTime] = useState<Date | null>(null)
@@ -865,7 +872,7 @@ function App(): JSX.Element {
   }
 
   return (
-    <div className="app">
+    <div className="app" data-theme={theme}>
       {/* Header */}
       <div className="header">
         <h1>Excalidraw Canvas</h1>
@@ -919,13 +926,17 @@ function App(): JSX.Element {
         >
           <Excalidraw
             excalidrawAPI={(api: ExcalidrawAPIRefValue) => setExcalidrawAPI(api)}
-            onChange={() => {
+            onChange={(_elements, appState) => {
+              if (appState.theme !== theme) {
+                setTheme(appState.theme)
+                window.localStorage?.setItem('excalidraw-canvas-theme', appState.theme)
+              }
               scheduleAutoSync()
             }}
             initialData={{
               elements: [],
               appState: {
-                theme: 'light',
+                theme,
                 viewBackgroundColor: '#ffffff'
               }
             }}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -308,8 +308,12 @@ function App(): JSX.Element {
 
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
     if (typeof window === 'undefined') return 'light'
-    const saved = window.localStorage?.getItem('excalidraw-canvas-theme')
-    if (saved === 'light' || saved === 'dark') return saved
+    try {
+      const saved = window.localStorage?.getItem('excalidraw-canvas-theme')
+      if (saved === 'light' || saved === 'dark') return saved
+    } catch (error) {
+      console.warn('Failed to read theme from localStorage:', error)
+    }
     return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
   })
 
@@ -927,17 +931,20 @@ function App(): JSX.Element {
           <Excalidraw
             excalidrawAPI={(api: ExcalidrawAPIRefValue) => setExcalidrawAPI(api)}
             onChange={(_elements, appState) => {
-              if (appState.theme !== theme) {
+              if (appState?.theme && appState.theme !== theme) {
                 setTheme(appState.theme)
-                window.localStorage?.setItem('excalidraw-canvas-theme', appState.theme)
+                try {
+                  window.localStorage?.setItem('excalidraw-canvas-theme', appState.theme)
+                } catch (error) {
+                  console.warn('Failed to save theme to localStorage:', error)
+                }
               }
               scheduleAutoSync()
             }}
             initialData={{
               elements: [],
               appState: {
-                theme,
-                viewBackgroundColor: '#ffffff'
+                theme
               }
             }}
           />


### PR DESCRIPTION
The canvas page didn't follow dark mode. The header and page background stayed light, and a strip of light showed below the canvas because its height was hardcoded to `calc(100vh - 80px)`, which doesn't match the actual header height. The editor also reset to light on every reload.

This makes the page chrome follow the editor's theme through a `data-theme` attribute with matching dark styles, seeds the editor's initial theme from a saved choice or the OS setting, and switches the layout to a flex column so the canvas always fills the viewport with no leftover background.

<img width="1257" height="867" alt="image" src="https://github.com/user-attachments/assets/98b0c4b7-9308-4437-a428-670acf508a3b" />
