### PR TITLE
fix: mermaid conversion wiped the scene; dedupe WebSocket connections

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -403,7 +403,12 @@ function App(): JSX.Element {
   }
 
   const connectWebSocket = (): void => {
-    if (websocketRef.current && websocketRef.current.readyState === WebSocket.OPEN) {
+    // Guard CONNECTING too: the mount effect and the excalidrawAPI effect can
+    // both run before the first socket opens, orphaning a live duplicate
+    // connection whose handlers then process every broadcast twice.
+    if (websocketRef.current &&
+        (websocketRef.current.readyState === WebSocket.CONNECTING ||
+         websocketRef.current.readyState === WebSocket.OPEN)) {
       return
     }
 
@@ -734,9 +739,15 @@ function App(): JSX.Element {
               }
 
               if (result.elements && result.elements.length > 0) {
-                const convertedElements = convertToExcalidrawElements(result.elements, { regenerateIds: false })
+                // Regenerate ids so repeated conversions of the same diagram
+                // (mermaid emits stable ids like "A", "B") can't collide with
+                // elements already on the canvas.
+                const convertedElements = convertToExcalidrawElements(result.elements, { regenerateIds: true })
+                // Merge with the existing scene — updateScene() replaces the
+                // element list wholesale, and syncToBackend() would otherwise
+                // propagate that wipe to the server.
                 applySceneUpdateWithoutAutoSync(excalidrawAPI, {
-                  elements: convertedElements,
+                  elements: [...excalidrawAPI.getSceneElements(), ...convertedElements],
                   captureUpdate: CaptureUpdateAction.IMMEDIATELY
                 })
 
@@ -784,7 +795,10 @@ function App(): JSX.Element {
   const syncToBackend = async (options: { silent?: boolean } = {}): Promise<void> => {
     const { silent = false } = options
 
-    if (!excalidrawAPI) {
+    // Read through the ref: WS message handlers attached at mount capture a
+    // stale closure where the excalidrawAPI state is still null.
+    const api = excalidrawAPIRef.current
+    if (!api) {
       console.warn('Excalidraw API not available')
       return
     }
@@ -805,7 +819,7 @@ function App(): JSX.Element {
 
     try {
       // 1. Get current elements
-      const currentElements = excalidrawAPI.getSceneElements()
+      const currentElements = api.getSceneElements()
       console.log(`Syncing ${currentElements.length} elements to backend`)
 
       // Filter out deleted elements


### PR DESCRIPTION
## Problem

Full-repo QA after the recent merges surfaced two latent frontend bugs (both dating to #61, confirmed via `git log -L`):

- **Mermaid conversion destroyed the existing canvas.** The `mermaid_convert` handler passed only the converted elements to `updateScene()` (which replaces, never merges), then `syncToBackend()` pushed the wipe to the server. Repro: add any element → run `mermaid` → element gone. Went unnoticed because evals always ran mermaid on an empty canvas.
- **Every browser tab opened 2 WebSocket connections** (`/health` showed `websocket_clients: 2` for a single tab) due to a connect race — the `readyState === OPEN` guard missed a still-CONNECTING socket, orphaning a live duplicate. Every broadcast was handled twice: elements created via CLI/MCP while a tab was open got their label expanded into **two** bound text elements after the next sync.

## Fix

- **Mermaid**: merge `[...getSceneElements(), ...convertedElements]` and switch to `regenerateIds: true` so re-running a diagram (mermaid emits stable ids like `A`, `B`) can't collide with elements already on the canvas.
- **WebSocket**: guard `CONNECTING` as well as `OPEN` in `connectWebSocket`.
- Fixing the duplicate socket exposed a third bug it had been masking: `syncToBackend` read `excalidrawAPI` from a stale closure (null for handlers attached at mount), silently skipping the post-mermaid sync. It now reads through `excalidrawAPIRef`, matching the file's existing pattern for WS handlers.

## Verified

- One tab → `websocket_clients: 1`; a labeled element created via CLI syncs back as exactly one bound text
- A pre-existing element survives mermaid conversion; mermaid elements land on both canvas and server
- Re-running the same diagram adds a second copy cleanly (stacked at the same coordinates — mermaid converts at fixed positions; previously a re-run replaced the whole scene). A future nicety would be offsetting repeat conversions.
- `npm run build` clean; a `tsc` diff against `main`'s App.tsx confirms zero new type diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
