### PR TITLE
[fix] preserve edited text inside shapes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -167,7 +167,7 @@ const CreateElementSchema = z.object({
   fileId: z.string().optional(),
   status: z.string().optional(),
   scale: z.tuple([z.number(), z.number()]).optional(),
-});
+}).passthrough();
 
 const UpdateElementSchema = z.object({
   id: z.string(),
@@ -225,7 +225,7 @@ const UpdateElementSchema = z.object({
   fileId: z.string().optional(),
   status: z.string().optional(),
   scale: z.tuple([z.number(), z.number()]).optional(),
-});
+}).passthrough();
 
 // API Routes
 


### PR DESCRIPTION
## Problem
Text inside a shape could disappear after editing and clicking elsewhere on the canvas (video below).

Zod removed Excalidraw properties such as `containerId`, `originalText`, and `autoResize` because they were not declared in the create and update schemas. Without these properties, Excalidraw could lose the relationship between text and its containing shape.

## Fix
Enable `.passthrough()` on `CreateElementSchema` and `UpdateElementSchema` to preserve additional Excalidraw properties while continuing to validate known ones.

## Verification
- Reproduced the issue without `.passthrough()`
- Confirmed the properties are preserved and edited text no longer disappears

## Before

https://github.com/user-attachments/assets/2876b6c2-c0ce-43bc-bbdc-14216fb1ab7d

## After

https://github.com/user-attachments/assets/b23d1517-f805-43b4-932f-72ea3b2223be

