### PR TITLE
chore: release 2.0.0 — interchange-grade exports & MCP 2026-07-28

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,19 @@ Excalidraw has an [official MCP](https://github.com/excalidraw/excalidraw-mcp) �
 
 ## What's New
 
-Current package version: **1.1.0**. The current release line is **v1.1 — CLI-First**.
+Current package version: **2.0.0**. The current release line is **v2.0 — Interchange-Grade Exports & MCP 2026-07-28**.
+
+### v2.0 — Interchange-Grade Exports & MCP 2026-07-28
+
+- **Breaking: Node >= 20 required** (was 18) — the MCP TypeScript SDK v2 sets the floor. Everything else is backward compatible, including existing MCP client configs.
+- **MCP protocol revision 2026-07-28**: modern clients can call tools statelessly without an initialization handshake (`server/discover`, per-request `_meta` envelopes); legacy initialization-based clients keep working unchanged. (#98, thanks @anxkhn)
+- **Exports render everywhere now**: `.excalidraw` / `.excalidraw.md` files contain real Excalidraw elements — shape and arrow labels as bound text, live arrow bindings — so they open correctly on excalidraw.com and in the Obsidian Excalidraw plugin instead of losing labels (or being re-saved empty by the plugin). (#93, #95)
+- **Byte-stable exports**: deterministic ids, seeds, and key order — re-exporting an unchanged scene is byte-identical, so committed diagrams and vault files never produce phantom git diffs, and Obsidian block references survive re-exports.
+- **Obsidian vault fixes**: Windows/CRLF `.excalidraw.md` files import correctly (#94, thanks @cason-miles); `## Text Elements` block references now cover shape labels too.
+- **Element fields are never silently dropped**: unknown Excalidraw properties (`containerId`, `textAlign`, `originalText`, ...) pass through the server intact — fixes browser-edited text vanishing after sync. (#92, thanks @junuxyz)
+- **Mermaid conversion merges** into the existing canvas instead of replacing it, and each browser tab holds exactly one WebSocket connection (no more doubled labels). (#91)
+- **Viewport control**: `set_viewport` gains `scrollToElementIds` (multi-element zoom-to-fit) and `viewportZoomFactor`, with strict single-mode validation and real error reporting. (#86, thanks @acercyc)
+- **Dark mode**: the canvas page chrome follows the editor theme and persists it across reloads. (#89, thanks @danielsvane)
 
 ### v1.1 — CLI-First
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-excalidraw-server",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-excalidraw-server",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-excalidraw-server",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Excalidraw toolkit for AI coding agents — agent skill, CLI, and MCP server with a live canvas",
   "main": "dist/index.js",
   "type": "module",

--- a/src/core/expand-elements.ts
+++ b/src/core/expand-elements.ts
@@ -21,7 +21,7 @@ export interface ExpandOptions {
 // rest alphabetical — so a no-op import→export cycle is byte-identical and
 // committed .excalidraw files produce minimal git diffs.
 const KEY_ORDER = ['id', 'type', 'x', 'y', 'width', 'height'];
-function canonicalizeKeys(v: any): any {
+export function canonicalizeKeys(v: any): any {
   if (Array.isArray(v)) return v.map(canonicalizeKeys);
   if (v && typeof v === 'object') {
     const keys = Object.keys(v).sort((a, b) => {

--- a/src/core/obsidian-md.ts
+++ b/src/core/obsidian-md.ts
@@ -13,6 +13,8 @@
 // every scene reference rewired — so files we write and files the plugin
 // re-saves stay block-reference-compatible.
 
+import { canonicalizeKeys } from './expand-elements.js';
+
 const ID_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 // Obsidian block ids are alphanumeric-and-dash only — an id containing "_"
 // would be written as an unresolvable block reference, so rename those too.
@@ -104,7 +106,7 @@ ${textSection}
 %%
 ## Drawing
 \`\`\`json
-${JSON.stringify(wrapped, null, '\t')}
+${JSON.stringify(canonicalizeKeys(wrapped), null, '\t')}
 \`\`\`
 %%`;
 }
@@ -113,14 +115,18 @@ export function extractSceneJsonFromObsidianMd(md: string): string {
   // The closing fence must sit at the start of a line: element text can
   // contain ``` inside the JSON strings, but a line of pretty-printed JSON
   // never begins with a backtick (this mirrors the plugin's own DRAWING_REG).
-  const compressed = md.match(/\n##? Drawing\n[^`]*```compressed-json\n([\s\S]*?)\n```/);
+  //
+  // Every line break matches `\r?\n`: files authored on Windows (or by the
+  // Obsidian plugin there) use CRLF, and requiring a bare `\n` made every
+  // such file fail with a misleading "No Drawing block found".
+  const compressed = md.match(/\r?\n##? Drawing\r?\n[^`]*```compressed-json\r?\n([\s\S]*?)\r?\n```/);
   if (compressed) {
     const json = decompressFromBase64(compressed[1]!.replace(/\s/g, ''));
     if (!json) throw new Error('Failed to decompress the Drawing block');
     JSON.parse(json);
     return json;
   }
-  const plain = md.match(/\n##? Drawing\n[^`]*```json\n([\s\S]*?)\n```/);
+  const plain = md.match(/\r?\n##? Drawing\r?\n[^`]*```json\r?\n([\s\S]*?)\r?\n```/);
   if (plain) {
     JSON.parse(plain[1]!);
     return plain[1]!;


### PR DESCRIPTION
## Release 2.0.0 — Interchange-Grade Exports & MCP 2026-07-28

Final pieces + version bump + README announcement for the 2.0.0 release, covering everything merged since the published 1.1.0: #86, #89, #90, #91, #92, #95, #98.

### In this PR

- **`.excalidraw.md` byte-stability companion**: canonicalize the obsidian wrap's Drawing JSON so field passthrough (#92) can't reorder keys across import/export cycles
- **CRLF vault imports** (from #94, credited via `Co-authored-by`): Drawing-block extraction matches `\r?\n`, so Windows-authored vault files import instead of failing with "No Drawing block found"
- **Version bump to 2.0.0** — major because #98 raises the Node floor to 20 (SDK v2 requirement)
- **README "What's New"** section announcing the release line with contributor credits

### Release QA (all passing)

- CRLF and LF `.excalidraw.md` imports; plain markdown still rejected
- Byte-identical no-op import→export cycles for both `.excalidraw` and `.excalidraw.md`
- #92 field passthrough intact (`textAlign` preserved through import)
- MCP stdio wire tests 5/5 (modern discover, init-free calls, version refusal, malformed meta, legacy handshake)
- `--version` reports 2.0.0; tarball smoke test from `npm pack` verified earlier in the cycle

### After merging

1. `npm publish` (prepublishOnly rebuilds; registry jump 1.1.0 → 2.0.0)
2. `git tag v2.0.0 && git push --tags` + GitHub release with the README notes
3. Close #94 with thanks (attribution commit `de999fa`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
