### PR TITLE
Fix duplicate labels during canvas synchronization

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import {
 import type { ExcalidrawElement, NonDeleted, NonDeletedExcalidrawElement } from '@excalidraw/excalidraw/types/element/types'
 import { convertMermaidToExcalidraw, DEFAULT_MERMAID_CONFIG } from './utils/mermaidConverter'
 import type { MermaidConfig } from '@excalidraw/mermaid-to-excalidraw'
+import { withStableGeneratedBoundTextIds } from '../../src/core/bound-text'
 
 // Type definitions
 type ExcalidrawAPIRefValue = ExcalidrawImperativeAPI;
@@ -297,9 +298,10 @@ const convertElementsPreservingImageProps = (
   const imageElements = validatedElements.filter(isImageElement).map(normalizeImageElement)
   const freedrawElements = validatedElements.filter(isFreedrawElement).map(normalizeFreedrawElement)
   const nonImageElements = validatedElements.filter(el => !isImageElement(el) && !isFreedrawElement(el))
+  const stableNonImageElements = withStableGeneratedBoundTextIds(nonImageElements)
   // convertToExcalidrawElements may expand labeled shapes into [shape, textElement],
   // so we cannot assume a 1:1 mapping — return all converted elements directly.
-  const convertedNonImageElements = convertToExcalidrawElements(nonImageElements as any, { regenerateIds: false })
+  const convertedNonImageElements = convertToExcalidrawElements(stableNonImageElements as any, { regenerateIds: false })
   const restoredNonImageElements = restoreBindings(convertedNonImageElements, nonImageElements)
   return recenterBoundShapeTextElements([...restoredNonImageElements, ...imageElements, ...freedrawElements])
 }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     "production": "npm run build && npm run canvas",
     "prepublishOnly": "npm run build",
     "sync:skills": "node scripts/sync-skills.mjs",
-    "test": "npm run test:mcp && npm run test:bind",
+    "test": "npm run test:mcp && npm run test:bind && npm run test:labels",
     "test:bind": "npm run build:server && node scripts/check-local-bind.mjs",
+    "test:labels": "npm run build:server && node scripts/check-bound-text-ids.mjs",
     "test:mcp": "npm run build:server && node scripts/check-mcp-stdio.mjs",
     "type-check": "npx tsc --noEmit"
   },

--- a/scripts/check-bound-text-ids.mjs
+++ b/scripts/check-bound-text-ids.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { withStableGeneratedBoundTextIds } from '../dist/core/bound-text.js';
+
+const labelledShape = {
+  id: 'box',
+  type: 'rectangle',
+  label: { text: 'hello' },
+  boundElements: null,
+};
+const [normalized] = withStableGeneratedBoundTextIds([labelledShape]);
+assert.deepEqual(normalized.label, { id: 'box-label', text: 'hello' });
+
+const browserOwned = {
+  ...labelledShape,
+  boundElements: [{ type: 'text', id: 'browser-text' }],
+};
+assert.deepEqual(withStableGeneratedBoundTextIds([browserOwned]), [browserOwned]);
+
+const explicitLabelId = {
+  ...labelledShape,
+  label: { id: 'custom-label', text: 'hello' },
+};
+assert.deepEqual(withStableGeneratedBoundTextIds([explicitLabelId]), [explicitLabelId]);
+
+console.log('Bound-text ID check passed: generated labels receive stable identities.');

--- a/src/core/bound-text.ts
+++ b/src/core/bound-text.ts
@@ -1,0 +1,26 @@
+interface BoundTextInput {
+  id?: string;
+  type?: string;
+  label?: { id?: string; text?: string };
+  boundElements?: readonly { type: string }[] | null;
+}
+
+export function withStableGeneratedBoundTextIds<T extends BoundTextInput>(elements: readonly T[]): T[] {
+  return elements.map((element) => {
+    const hasBoundText = element.boundElements?.some((binding) => binding.type === 'text');
+    if (
+      !element.id ||
+      element.type === 'text' ||
+      !element.label?.text ||
+      element.label.id ||
+      hasBoundText
+    ) {
+      return element;
+    }
+
+    return {
+      ...element,
+      label: { ...element.label, id: `${element.id}-label` },
+    };
+  });
+}


### PR DESCRIPTION
## What changed

- Give agent-friendly labels the deterministic identity `<container-id>-label` before passing them to Excalidraw.
- Preserve browser-owned and explicitly supplied label identities.
- Add a regression for generated, browser-owned, and explicitly identified labels.

## Root cause

`convertToExcalidrawElements(..., { regenerateIds: false })` preserves the container ID but still creates a random ID for bound text unless the input label supplies one. Independent browser clients or repeated restoration passes therefore materialize different text elements for the same container. Once those scenes are merged or synchronized, the duplicate labels become persistent canvas elements.

The existing `CONNECTING` WebSocket guard removes one common trigger, but deterministic generated-label identity is still required for retries and multiple legitimate browser clients.

## Impact

Repeated canvas restoration and synchronization are now idempotent for agent-created labels. Excalidraw remains responsible for creating and binding the text element; the server only supplies its stable identity. Existing labels created and edited by the browser retain their original identities.

## Validation

- Browser probe: three real Excalidraw conversions previously produced three random text IDs; supplying the label ID makes all three produce `box-label` directly.
- Collision probe: Excalidraw resolves an existing `box-label` collision to one freshly generated bound label.
- Two-client integration probe: two headless browser clients synchronized the same labeled rectangle and produced exactly `probe-box` plus `probe-box-label`.
- `npm test`
- `npm run type-check`
- `npm run build`
- `git diff --check`
