### PR TITLE
fix: harden npm release workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,8 +14,11 @@ jobs:
   publish:
     name: Publish to NPM Registry
     runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.package-version.outputs.version }}
+      version_exists: ${{ steps.check-version.outputs.exists }}
     permissions:
-      contents: read
+      contents: write
       id-token: write
 
     steps:
@@ -50,15 +53,48 @@ jobs:
         id: package-version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
+      - name: Verify release tag
+        if: github.event_name == 'release'
+        env:
+          PACKAGE_VERSION: ${{ steps.package-version.outputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          expected_tag="v${PACKAGE_VERSION}"
+          if [ "$RELEASE_TAG" != "$expected_tag" ]; then
+            echo "::error::Release tag $RELEASE_TAG does not match package version $PACKAGE_VERSION (expected $expected_tag)"
+            exit 1
+          fi
+
       - name: Check if version exists on NPM
         id: check-version
+        env:
+          PACKAGE_VERSION: ${{ steps.package-version.outputs.version }}
         run: |
-          if npm view mcp-excalidraw-server@${{ steps.package-version.outputs.version }} version 2>/dev/null; then
+          set +e
+          npm_output=$(npm view "mcp-excalidraw-server@${PACKAGE_VERSION}" version 2>&1)
+          npm_status=$?
+          set -e
+
+          if [ "$npm_status" -eq 0 ]; then
             echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Version ${{ steps.package-version.outputs.version }} already exists on NPM"
-          else
+            echo "Version $PACKAGE_VERSION already exists on NPM"
+          elif printf '%s\n' "$npm_output" | grep -q 'E404'; then
             echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Version ${{ steps.package-version.outputs.version }} does not exist on NPM"
+            echo "Version $PACKAGE_VERSION does not exist on NPM"
+          else
+            printf '%s\n' "$npm_output"
+            echo "::error::Unable to determine whether version $PACKAGE_VERSION exists on NPM"
+            exit "$npm_status"
+          fi
+
+      - name: Verify NPM publish token
+        if: steps.check-version.outputs.exists == 'false'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::NPM_TOKEN is not configured in this repository's Actions secrets"
+            exit 1
           fi
 
       - name: Publish to NPM (Release)
@@ -76,8 +112,7 @@ jobs:
       - name: Skip publishing (version exists)
         if: steps.check-version.outputs.exists == 'true'
         run: |
-          echo "⚠️  Skipping publish - version ${{ steps.package-version.outputs.version }} already exists on NPM"
-          echo "Please bump the version in package.json before publishing"
+          echo "Skipping NPM publish - version ${{ steps.package-version.outputs.version }} already exists"
 
       - name: Create GitHub Release Assets
         if: github.event_name == 'release'
@@ -86,7 +121,7 @@ jobs:
 
       - name: Upload Release Assets
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             mcp-excalidraw-server-${{ steps.package-version.outputs.version }}.tar.gz
@@ -101,6 +136,13 @@ jobs:
 
     steps:
       - name: Success notification
+        env:
+          PACKAGE_VERSION: ${{ needs.publish.outputs.package_version }}
+          VERSION_EXISTS: ${{ needs.publish.outputs.version_exists }}
         run: |
-          echo "✅ Package successfully published to NPM!"
-          echo "View at: https://www.npmjs.com/package/mcp-excalidraw-server"
+          if [ "$VERSION_EXISTS" = "true" ]; then
+            echo "mcp-excalidraw-server@$PACKAGE_VERSION already exists on NPM; publish was skipped"
+          else
+            echo "mcp-excalidraw-server@$PACKAGE_VERSION was successfully published to NPM"
+          fi
+          echo "View at: https://www.npmjs.com/package/mcp-excalidraw-server/v/$PACKAGE_VERSION"


### PR DESCRIPTION
## Summary
- grant the release job permission to upload GitHub Release assets and update `softprops/action-gh-release` to v2
- require release tags to match `v<package version>`
- distinguish an npm `E404` from registry/network failures before deciding a version is unpublished
- fail clearly when `NPM_TOKEN` is missing for a new version
- report truthfully when an existing npm version is skipped

## 2.0.0 release behavior
`mcp-excalidraw-server@2.0.0` was published manually. After this PR merges, publishing the `v2.0.0` GitHub Release will skip the duplicate npm publish and still build/upload the release asset. A repository `NPM_TOKEN` is still required before publishing the next new package version through Actions.

## Verification
- parsed the workflow as YAML
- ran Bash syntax checks against every workflow `run` block
- verified the matching `v2.0.0` tag path
- verified mismatched tags and empty publish tokens fail
- verified the live npm `2.0.0` metadata selects the existing-version skip path
- `git diff --check`