### PR TITLE
fix: treat zero-size text as unmeasured during export expansion

### DIFF
--- a/src/core/expand-elements.ts
+++ b/src/core/expand-elements.ts
@@ -114,11 +114,15 @@ export function expandElementsForExport(
       // Agent-created text often has no dimensions (server stores null);
       // third-party consumers clip width-less text, so estimate like the
       // design guide does (~0.6×fontSize per char, 1.25 line height).
-      if (base.width == null || base.height == null) {
+      // Treat 0 as unmeasured, not just null/undefined: pre-2.0.0 headless
+      // creation stored width/height 0, and re-imported scenes carry it back
+      // into the store — zero-size text renders invisible in consumers that
+      // trust stored dimensions.
+      if (!base.width || !base.height) {
         const lines = String(base.text).split('\n');
         const longestLine = Math.max(1, ...lines.map((l: string) => l.length));
-        base.width = base.width ?? Math.ceil(longestLine * base.fontSize * 0.6);
-        base.height = base.height ?? Math.ceil(lines.length * base.fontSize * 1.25);
+        base.width = base.width || Math.ceil(longestLine * base.fontSize * 0.6);
+        base.height = base.height || Math.ceil(lines.length * base.fontSize * 1.25);
       }
       base.fontFamily = normalizeFontFamily(rest.fontFamily) ?? 1;
       base.textAlign = rest.textAlign ?? 'center';


### PR DESCRIPTION
## Problem

`expandElementsForExport` estimates text dimensions only when `width`/`height` is `null`/`undefined`. But text elements can carry `width: 0, height: 0` instead — scenes created headless by pre-2.0 servers stored 0, and importing such a scene brings 0 back into the store. Zero passes the null-guard, so the text re-exports at 0×0 and renders invisible in consumers that trust stored dimensions (VS Code Excalidraw extension, Obsidian plugin).

## Repro

Import a scene containing `{ "type": "text", "width": 0, "height": 0, "text": "..." }` (as produced by pre-2.0 headless creation), then `export_scene` — the exported element still has `width: 0`.

## Fix

Treat 0 as unmeasured in the estimation guard (`!base.width || !base.height`). A `width: 0` fixture now exports measured (180×25 for a 15-char line at fontSize 20). Elements with real dimensions are unaffected, since a valid size is never 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
