### PR TITLE
fix: preserve native frames and guard scene reload sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,20 @@ jobs:
       - name: Run TypeScript type check
         run: npm run type-check
 
+      - name: Type check frontend
+        run: npm run type-check:frontend
+
       - name: Build project
         run: npm run build
 
       - name: Run MCP stdio wire tests
         run: node scripts/check-mcp-stdio.mjs
+
+      - name: Install Chromium for canvas regression tests
+        run: npx playwright install --with-deps chromium
+
+      - name: Run canvas browser regression tests
+        run: npx playwright test
 
       - name: Check build artifacts
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ public/dist/
 .DS_Store
 
 docs/
+
+# Browser regression artifacts
+test-results/
+playwright-report/

--- a/README.md
+++ b/README.md
@@ -490,6 +490,19 @@ curl http://127.0.0.1:3000/health
 npm run test:bind
 ```
 
+### Canvas Browser Regression Tests
+
+These Chromium tests build the app and start an isolated localhost server. They
+cover frame reload/reconnect, mixed scenes, failed-load sync protection, stale
+responses, clearing/deletion, Mermaid imports, and SVG export. They refuse to
+reuse an existing server; set `CANVAS_TEST_PORT` if port 51910 is occupied.
+
+```bash
+npx playwright install chromium
+npm run type-check:frontend
+npm run test:canvas
+```
+
 ### MCP Stdio Wire Test
 
 Drives `dist/index.js` with raw JSON-RPC frames and checks both protocol eras:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -95,6 +95,22 @@
             width: 100%;
             position: relative;
         }
+
+        .scene-load-status {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 10px 20px;
+            border-bottom: 1px solid #d6a23d;
+            background: #fff3cd;
+            color: #614a14;
+        }
+
+        button:disabled {
+            cursor: not-allowed;
+            opacity: 0.55;
+        }
         
         /* Sync Controls Styles */
         .sync-controls {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,60 +3,23 @@ import {
   Excalidraw,
   convertToExcalidrawElements,
   CaptureUpdateAction,
-  ExcalidrawImperativeAPI,
   exportToBlob,
   exportToSvg
 } from '@excalidraw/excalidraw'
-import type { ExcalidrawElement, NonDeleted, NonDeletedExcalidrawElement } from '@excalidraw/excalidraw/types/element/types'
+import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types'
+import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
 import { convertMermaidToExcalidraw, DEFAULT_MERMAID_CONFIG } from './utils/mermaidConverter'
+import { cleanElementForExcalidraw, prepareServerScene, assertScenePreserved } from './utils/scene'
+import type { ServerElement } from './utils/scene'
 import type { MermaidConfig } from '@excalidraw/mermaid-to-excalidraw'
 
 // Type definitions
 type ExcalidrawAPIRefValue = ExcalidrawImperativeAPI;
 
-interface ServerElement {
-  id: string;
-  type: string;
-  x: number;
-  y: number;
-  width?: number;
-  height?: number;
-  backgroundColor?: string;
-  strokeColor?: string;
-  strokeWidth?: number;
-  roughness?: number;
-  opacity?: number;
-  text?: string;
-  fontSize?: number;
-  fontFamily?: string | number;
-  label?: {
-    text: string;
-  };
-  createdAt?: string;
-  updatedAt?: string;
-  version?: number;
-  syncedAt?: string;
-  source?: string;
-  syncTimestamp?: string;
-  boundElements?: any[] | null;
-  containerId?: string | null;
-  locked?: boolean;
-  // Arrow element binding
-  start?: { id: string };
-  end?: { id: string };
-  strokeStyle?: string;
-  endArrowhead?: string;
-  startArrowhead?: string;
-  // Image element fields
-  fileId?: string;
-  status?: string;
-  scale?: [number, number];
-  angle?: number;
-  link?: string | null;
-}
-
 interface WebSocketMessage {
   type: string;
+  format?: 'png' | 'svg';
+  background?: boolean;
   element?: ServerElement;
   elements?: ServerElement[];
   elementId?: string;
@@ -86,223 +49,11 @@ interface ApiResponse {
 }
 
 type SyncStatus = 'idle' | 'syncing' | 'success' | 'error';
+type SceneLoadStatus = 'loading' | 'ready' | 'failed';
 const AUTO_SYNC_DEBOUNCE_MS = 1200;
-
-// Helper function to clean elements for Excalidraw
-const cleanElementForExcalidraw = (element: ServerElement): Partial<ExcalidrawElement> => {
-  const {
-    createdAt,
-    updatedAt,
-    version,
-    syncedAt,
-    source,
-    syncTimestamp,
-    ...cleanElement
-  } = element;
-  return cleanElement;
-}
-
-// Helper function to validate and fix element binding data
-const validateAndFixBindings = (elements: Partial<ExcalidrawElement>[]): Partial<ExcalidrawElement>[] => {
-  const elementMap = new Map(elements.map(el => [el.id!, el]));
-
-  return elements.map(element => {
-    const fixedElement = { ...element };
-
-    // Validate and fix boundElements
-    if (fixedElement.boundElements) {
-      if (Array.isArray(fixedElement.boundElements)) {
-        fixedElement.boundElements = fixedElement.boundElements.filter((binding: any) => {
-          // Ensure binding has required properties
-          if (!binding || typeof binding !== 'object') return false;
-          if (!binding.id || !binding.type) return false;
-
-          // Ensure the referenced element exists
-          const referencedElement = elementMap.get(binding.id);
-          if (!referencedElement) return false;
-
-          // Validate binding type
-          if (!['text', 'arrow'].includes(binding.type)) return false;
-
-          return true;
-        });
-
-        // Remove boundElements if empty
-        if (fixedElement.boundElements.length === 0) {
-          fixedElement.boundElements = null;
-        }
-      } else {
-        // Invalid boundElements format, set to null
-        fixedElement.boundElements = null;
-      }
-    }
-
-    // Validate and fix containerId
-    if (fixedElement.containerId) {
-      const containerElement = elementMap.get(fixedElement.containerId);
-      if (!containerElement) {
-        // Container doesn't exist, remove containerId
-        fixedElement.containerId = null;
-      }
-    }
-
-    return fixedElement;
-  });
-}
-
-const isImageElement = (element: Partial<ExcalidrawElement>): boolean => {
-  return element.type === 'image'
-}
-
-const isFreedrawElement = (element: Partial<ExcalidrawElement>): boolean => {
-  return element.type === 'freedraw'
-}
-
-const isShapeContainerType = (type: string | undefined): boolean => {
-  return type === 'rectangle' || type === 'ellipse' || type === 'diamond'
-}
-
-const recenterBoundShapeTextElements = (
-  elements: Partial<ExcalidrawElement>[]
-): Partial<ExcalidrawElement>[] => {
-  const elementMap = new Map(elements.map((el) => [el.id, el]))
-
-  return elements.map((element) => {
-    if (element.type !== 'text' || !element.containerId) {
-      return element
-    }
-
-    const textElement = element as ExcalidrawElement & { type: 'text'; containerId: string; autoResize?: boolean }
-    const container = elementMap.get(textElement.containerId) as (ExcalidrawElement & { x: number; y: number; width: number; height: number }) | undefined
-    if (!container || !isShapeContainerType(container.type)) {
-      return element
-    }
-
-    if (textElement.autoResize === false) {
-      return element
-    }
-
-    if (
-      typeof container.x !== 'number' ||
-      typeof container.y !== 'number' ||
-      typeof container.width !== 'number' ||
-      typeof container.height !== 'number' ||
-      typeof textElement.width !== 'number' ||
-      typeof textElement.height !== 'number'
-    ) {
-      return element
-    }
-
-    return {
-      ...element,
-      x: container.x + (container.width - textElement.width) / 2,
-      y: container.y + (container.height - textElement.height) / 2,
-    }
-  })
-}
-
-const normalizeImageElement = (element: Partial<ExcalidrawElement>): Partial<ExcalidrawElement> => {
-  const img = element as any
-  return {
-    ...img,
-    angle: img.angle || 0,
-    strokeColor: img.strokeColor || 'transparent',
-    backgroundColor: img.backgroundColor || 'transparent',
-    fillStyle: img.fillStyle || 'solid',
-    strokeWidth: img.strokeWidth || 1,
-    strokeStyle: img.strokeStyle || 'solid',
-    roughness: img.roughness ?? 0,
-    opacity: img.opacity ?? 100,
-    groupIds: img.groupIds || [],
-    roundness: null,
-    seed: img.seed || Math.floor(Math.random() * 1000000),
-    version: img.version || 1,
-    versionNonce: img.versionNonce || Math.floor(Math.random() * 1000000),
-    isDeleted: img.isDeleted ?? false,
-    boundElements: img.boundElements || null,
-    link: img.link || null,
-    locked: img.locked || false,
-    status: img.status || 'saved',
-    fileId: img.fileId,
-    scale: img.scale || [1, 1],
-  }
-}
-
-const normalizeFreedrawElement = (element: Partial<ExcalidrawElement>): Partial<ExcalidrawElement> => {
-  const freedraw = element as any
-  return {
-    ...freedraw,
-    angle: freedraw.angle || 0,
-    backgroundColor: freedraw.backgroundColor || 'transparent',
-    fillStyle: freedraw.fillStyle || 'solid',
-    strokeWidth: freedraw.strokeWidth || 1,
-    strokeStyle: freedraw.strokeStyle || 'solid',
-    roughness: freedraw.roughness ?? 1,
-    opacity: freedraw.opacity ?? 100,
-    groupIds: freedraw.groupIds || [],
-    roundness: null,
-    seed: freedraw.seed || Math.floor(Math.random() * 1000000),
-    version: freedraw.version || 1,
-    versionNonce: freedraw.versionNonce || Math.floor(Math.random() * 1000000),
-    isDeleted: freedraw.isDeleted ?? false,
-    boundElements: freedraw.boundElements || null,
-    link: freedraw.link || null,
-    locked: freedraw.locked || false,
-    points: freedraw.points || [],
-    pressures: freedraw.pressures || [],
-    simulatePressure: freedraw.simulatePressure ?? true,
-    lastCommittedPoint: freedraw.lastCommittedPoint || null,
-  }
-}
-
-// Helper: restore startBinding/endBinding/boundElements after convertToExcalidrawElements strips them
-const restoreBindings = (
-  convertedElements: readonly any[],
-  originalElements: Partial<ExcalidrawElement>[]
-): any[] => {
-  const originalMap = new Map<string, any>();
-  for (const el of originalElements) {
-    if (el.id) originalMap.set(el.id, el);
-  }
-
-  return convertedElements.map((el: any) => {
-    const orig = originalMap.get(el.id);
-    if (!orig) return el;
-
-    const patched = { ...el };
-
-    if (orig.startBinding && !el.startBinding) {
-      patched.startBinding = orig.startBinding;
-    }
-    if (orig.endBinding && !el.endBinding) {
-      patched.endBinding = orig.endBinding;
-    }
-    if (orig.boundElements && (!el.boundElements || el.boundElements.length === 0)) {
-      patched.boundElements = orig.boundElements;
-    }
-    if (orig.elbowed !== undefined && el.elbowed === undefined) {
-      patched.elbowed = orig.elbowed;
-    }
-
-    return patched;
-  });
-};
-
-const convertElementsPreservingImageProps = (
-  elements: Partial<ExcalidrawElement>[]
-): Partial<ExcalidrawElement>[] => {
-  if (elements.length === 0) return []
-
-  const validatedElements = validateAndFixBindings(elements)
-  const imageElements = validatedElements.filter(isImageElement).map(normalizeImageElement)
-  const freedrawElements = validatedElements.filter(isFreedrawElement).map(normalizeFreedrawElement)
-  const nonImageElements = validatedElements.filter(el => !isImageElement(el) && !isFreedrawElement(el))
-  // convertToExcalidrawElements may expand labeled shapes into [shape, textElement],
-  // so we cannot assume a 1:1 mapping — return all converted elements directly.
-  const convertedNonImageElements = convertToExcalidrawElements(nonImageElements as any, { regenerateIds: false })
-  const restoredNonImageElements = restoreBindings(convertedNonImageElements, nonImageElements)
-  return recenterBoundShapeTextElements([...restoredNonImageElements, ...imageElements, ...freedrawElements])
-}
+const SCENE_MUTATIONS = new Set([
+  'element_created', 'element_updated', 'element_deleted', 'elements_batch_created'
+]);
 
 function App(): JSX.Element {
   const [excalidrawAPI, setExcalidrawAPI] = useState<ExcalidrawAPIRefValue | null>(null)
@@ -313,6 +64,7 @@ function App(): JSX.Element {
   }, [excalidrawAPI])
   const [isConnected, setIsConnected] = useState<boolean>(false)
   const websocketRef = useRef<WebSocket | null>(null)
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
     if (typeof window === 'undefined') return 'light'
@@ -332,16 +84,65 @@ function App(): JSX.Element {
   const syncInFlightRef = useRef<boolean>(false)
   const suppressAutoSyncCountRef = useRef<number>(0)
   const userInteractedRef = useRef<boolean>(false)
+  const [sceneLoadStatus, setSceneLoadStatus] = useState<SceneLoadStatus>('loading')
+  const sceneLoadStatusRef = useRef<SceneLoadStatus>('loading')
+  const sceneGenerationRef = useRef(0)
+
+  const pauseSceneSync = (status: SceneLoadStatus = 'loading'): number => {
+    sceneGenerationRef.current += 1
+    sceneLoadStatusRef.current = status
+    setSceneLoadStatus(status)
+    if (autoSyncTimerRef.current) {
+      clearTimeout(autoSyncTimerRef.current)
+      autoSyncTimerRef.current = null
+    }
+    return sceneGenerationRef.current
+  }
+
+  const failSceneLoad = (error: unknown, generation = sceneGenerationRef.current): void => {
+    if (generation !== sceneGenerationRef.current) return
+    console.error('Scene load failed; backend sync is paused:', error)
+    pauseSceneSync('failed')
+  }
+
+  const canSyncScene = (): boolean =>
+    sceneLoadStatusRef.current === 'ready' && websocketRef.current?.readyState === WebSocket.OPEN
 
   const applySceneUpdateWithoutAutoSync = (
     api: ExcalidrawImperativeAPI,
     scene: Parameters<ExcalidrawImperativeAPI['updateScene']>[0]
   ): void => {
     suppressAutoSyncCountRef.current += 1
-    api.updateScene(scene)
-    setTimeout(() => {
-      suppressAutoSyncCountRef.current = Math.max(0, suppressAutoSyncCountRef.current - 1)
-    }, 0)
+    try {
+      api.updateScene(scene)
+    } finally {
+      setTimeout(() => {
+        suppressAutoSyncCountRef.current = Math.max(0, suppressAutoSyncCountRef.current - 1)
+      }, 0)
+    }
+  }
+
+  const applyServerScene = (
+    incoming: readonly Partial<ExcalidrawElement>[],
+    generation: number,
+    files?: Record<string, unknown>
+  ): void => {
+    const api = excalidrawAPIRef.current
+    if (!api || generation !== sceneGenerationRef.current) return
+    // Prepare everything before replacing the visible scene. restoreElements()
+    // can silently filter elements, so both conversion and API readback need checks.
+    const prepared = prepareServerScene(incoming)
+    const previous = api.getSceneElementsIncludingDeleted()
+    try {
+      if (files) api.addFiles(Object.values(files) as Parameters<typeof api.addFiles>[0])
+      applySceneUpdateWithoutAutoSync(api, { elements: prepared, captureUpdate: CaptureUpdateAction.NEVER })
+      assertScenePreserved(prepared, api.getSceneElements())
+    } catch (error) {
+      applySceneUpdateWithoutAutoSync(api, { elements: previous, captureUpdate: CaptureUpdateAction.NEVER })
+      throw error
+    }
+    sceneLoadStatusRef.current = 'ready'
+    setSceneLoadStatus('ready')
   }
 
   useEffect(() => {
@@ -356,49 +157,43 @@ function App(): JSX.Element {
   useEffect(() => {
     connectWebSocket()
     return () => {
-      if (websocketRef.current) {
-        websocketRef.current.close()
-      }
+      sceneGenerationRef.current += 1
+      sceneLoadStatusRef.current = 'loading'
+      const socket = websocketRef.current
+      websocketRef.current = null
+      socket?.close()
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current)
     }
   }, [])
 
   // Load existing elements when Excalidraw API becomes available
   useEffect(() => {
     if (excalidrawAPI) {
-      loadExistingElements()
-
-      // Ensure WebSocket is connected for real-time updates
-      if (!isConnected) {
-        connectWebSocket()
-      }
+      // initial_elements may arrive before the API exists. HTTP is the fallback;
+      // later WebSocket scenes invalidate this request through its generation.
+      if (sceneLoadStatusRef.current !== 'ready') void loadExistingElements()
     }
-  }, [excalidrawAPI, isConnected])
+  }, [excalidrawAPI])
 
   const loadExistingElements = async (): Promise<void> => {
+    if (!excalidrawAPIRef.current) return
+    const generation = pauseSceneSync()
     try {
-      const response = await fetch('/api/elements')
+      const response = await fetch('/api/elements', { signal: AbortSignal.timeout(10000) })
       const result: ApiResponse = await response.json()
-
-      if (result.success && result.elements && result.elements.length > 0) {
-        const cleanedElements = result.elements.map(cleanElementForExcalidraw)
-        const convertedElements = convertElementsPreservingImageProps(cleanedElements)
-        if (excalidrawAPI) {
-          applySceneUpdateWithoutAutoSync(excalidrawAPI, {
-            elements: convertedElements,
-            captureUpdate: CaptureUpdateAction.NEVER
-          })
-        }
+      if (generation !== sceneGenerationRef.current) return
+      if (!response.ok || !result.success || !Array.isArray(result.elements)) {
+        throw new Error(result.error || 'Invalid scene response')
       }
-
-      const filesResponse = await fetch('/api/files')
-      if (filesResponse.ok) {
-        const filesResult = await filesResponse.json() as ApiResponse
-        if (filesResult.files) {
-          excalidrawAPI?.addFiles(Object.values(filesResult.files))
-        }
+      const filesResponse = await fetch('/api/files', { signal: AbortSignal.timeout(10000) })
+      const filesResult = await filesResponse.json() as ApiResponse
+      if (generation !== sceneGenerationRef.current) return
+      if (!filesResponse.ok || !filesResult.files) {
+        throw new Error('Could not load scene files')
       }
+      applyServerScene(result.elements.map(cleanElementForExcalidraw), generation, filesResult.files)
     } catch (error) {
-      console.error('Error loading existing elements:', error)
+      failSceneLoad(error, generation)
     }
   }
 
@@ -415,43 +210,54 @@ function App(): JSX.Element {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
     const wsUrl = `${protocol}//${window.location.host}`
 
-    websocketRef.current = new WebSocket(wsUrl)
+    const socket = new WebSocket(wsUrl)
+    websocketRef.current = socket
 
-    websocketRef.current.onopen = () => {
+    socket.onopen = () => {
+      if (websocketRef.current !== socket) return
       setIsConnected(true)
-
-      if (excalidrawAPI) {
-        setTimeout(loadExistingElements, 100)
-      }
+      void loadExistingElements()
     }
 
-    websocketRef.current.onmessage = (event: MessageEvent) => {
+    socket.onmessage = (event: MessageEvent) => {
+      if (websocketRef.current !== socket) return
       try {
         const data: WebSocketMessage = JSON.parse(event.data)
-        handleWebSocketMessage(data)
+        void handleWebSocketMessage(data)
       } catch (error) {
-        console.error('Error parsing WebSocket message:', error, event.data)
+        failSceneLoad(error)
       }
     }
 
-    websocketRef.current.onclose = (event: CloseEvent) => {
+    socket.onclose = (event: CloseEvent) => {
+      if (websocketRef.current !== socket) return
       setIsConnected(false)
+      pauseSceneSync()
 
       // Reconnect after 3 seconds if not a clean close
       if (event.code !== 1000) {
-        setTimeout(connectWebSocket, 3000)
+        reconnectTimerRef.current = setTimeout(connectWebSocket, 3000)
       }
     }
 
-    websocketRef.current.onerror = (error: Event) => {
+    socket.onerror = (error: Event) => {
+      if (websocketRef.current !== socket) return
       console.error('WebSocket error:', error)
       setIsConnected(false)
+      pauseSceneSync()
     }
   }
 
   const handleWebSocketMessage = async (data: WebSocketMessage): Promise<void> => {
     const excalidrawAPI = excalidrawAPIRef.current
     if (!excalidrawAPI) {
+      return
+    }
+
+    if (SCENE_MUTATIONS.has(data.type) && sceneLoadStatusRef.current !== 'ready') {
+      // An incremental event cannot prove that a failed or pending full load
+      // was complete. Fetch the current full scene instead of reopening sync.
+      void loadExistingElements()
       return
     }
 
@@ -476,26 +282,15 @@ function App(): JSX.Element {
 
         mergedElements.push(...incomingById.values())
 
-        const convertedElements = convertElementsPreservingImageProps(mergedElements)
-        applySceneUpdateWithoutAutoSync(excalidrawAPI, {
-          elements: convertedElements,
-          captureUpdate: CaptureUpdateAction.NEVER
-        })
+        applyServerScene(mergedElements, pauseSceneSync())
       }
 
       switch (data.type) {
         case 'initial_elements':
-          if (data.elements && data.elements.length > 0) {
-            const cleanedElements = data.elements.map(cleanElementForExcalidraw)
-            const convertedElements = convertElementsPreservingImageProps(cleanedElements)
-            applySceneUpdateWithoutAutoSync(excalidrawAPI, {
-              elements: convertedElements,
-              captureUpdate: CaptureUpdateAction.NEVER
-            })
-          }
-          // Load files for image elements
-          if ((data as any).files) {
-            excalidrawAPI.addFiles(Object.values((data as any).files))
+          {
+            const generation = pauseSceneSync()
+            if (!Array.isArray(data.elements)) throw new Error('Invalid initial scene')
+            applyServerScene(data.elements.map(cleanElementForExcalidraw), generation, (data as any).files)
           }
           break
 
@@ -506,6 +301,7 @@ function App(): JSX.Element {
           break
 
         case 'element_created':
+          if (!data.element) throw new Error('Missing created element')
           if (data.element) {
             const cleanedNewElement = cleanElementForExcalidraw(data.element)
             // Rebuild against full scene so text/container bindings remain intact.
@@ -514,6 +310,7 @@ function App(): JSX.Element {
           break
 
         case 'element_updated':
+          if (!data.element) throw new Error('Missing updated element')
           if (data.element) {
             const cleanedUpdatedElement = cleanElementForExcalidraw(data.element)
             // Convert with full scene context so text metrics/container placement can refresh.
@@ -522,16 +319,15 @@ function App(): JSX.Element {
           break
 
         case 'element_deleted':
+          if (!data.elementId) throw new Error('Missing deleted element ID')
           if (data.elementId) {
             const filteredElements = currentElements.filter(el => el.id !== data.elementId)
-            applySceneUpdateWithoutAutoSync(excalidrawAPI, {
-              elements: filteredElements,
-              captureUpdate: CaptureUpdateAction.NEVER
-            })
+            applyServerScene(filteredElements, pauseSceneSync())
           }
           break
 
         case 'elements_batch_created':
+          if (!Array.isArray(data.elements)) throw new Error('Invalid element batch')
           if (data.elements) {
             const cleanedBatchElements = data.elements.map(cleanElementForExcalidraw)
             mergeAndApplySceneElements(cleanedBatchElements)
@@ -549,15 +345,13 @@ function App(): JSX.Element {
 
         case 'canvas_cleared':
           console.log('Canvas cleared by server')
-          applySceneUpdateWithoutAutoSync(excalidrawAPI, {
-            elements: [],
-            captureUpdate: CaptureUpdateAction.NEVER
-          })
+          applyServerScene([], pauseSceneSync())
           break
 
         case 'export_image_request':
           if (data.requestId) {
             try {
+              if (!canSyncScene()) throw new Error('Scene is not fully loaded; export is paused')
               const elements = excalidrawAPI.getSceneElements()
               const appState = excalidrawAPI.getAppState()
               const files = excalidrawAPI.getFiles()
@@ -731,7 +525,10 @@ function App(): JSX.Element {
           console.log('Received Mermaid conversion request from MCP')
           if (data.mermaidDiagram) {
             try {
+              if (!canSyncScene()) throw new Error('Scene is not fully loaded; Mermaid import is paused')
+              const generation = sceneGenerationRef.current
               const result = await convertMermaidToExcalidraw(data.mermaidDiagram, data.config || DEFAULT_MERMAID_CONFIG)
+              if (!canSyncScene() || generation !== sceneGenerationRef.current) return
 
               if (result.error) {
                 console.error('Mermaid conversion error:', result.error)
@@ -742,7 +539,7 @@ function App(): JSX.Element {
                 // Regenerate ids so repeated conversions of the same diagram
                 // (mermaid emits stable ids like "A", "B") can't collide with
                 // elements already on the canvas.
-                const convertedElements = convertToExcalidrawElements(result.elements, { regenerateIds: true })
+                const convertedElements = convertToExcalidrawElements([...result.elements] as Parameters<typeof convertToExcalidrawElements>[0], { regenerateIds: true })
                 // Merge with the existing scene — updateScene() replaces the
                 // element list wholesale, and syncToBackend() would otherwise
                 // propagate that wipe to the server.
@@ -771,6 +568,9 @@ function App(): JSX.Element {
       }
     } catch (error) {
       console.error('Error processing WebSocket message:', error, data)
+      if (data.type === 'initial_elements' || data.type === 'canvas_cleared' || SCENE_MUTATIONS.has(data.type)) {
+        failSceneLoad(error)
+      }
     }
   }
 
@@ -794,6 +594,9 @@ function App(): JSX.Element {
   // Main sync function
   const syncToBackend = async (options: { silent?: boolean } = {}): Promise<void> => {
     const { silent = false } = options
+    // Every caller, including manual sync and Mermaid, must respect a failed
+    // restore. A user interaction alone is not evidence of a complete scene.
+    if (!canSyncScene()) return
 
     // Read through the ref: WS message handlers attached at mount capture a
     // stale closure where the excalidrawAPI state is still null.
@@ -868,7 +671,7 @@ function App(): JSX.Element {
   }
 
   const scheduleAutoSync = (): void => {
-    if (!isConnected || !excalidrawAPI) {
+    if (!canSyncScene() || !excalidrawAPI) {
       return
     }
     if (!userInteractedRef.current) {
@@ -891,32 +694,18 @@ function App(): JSX.Element {
   }
 
   const clearCanvas = async (): Promise<void> => {
-    if (excalidrawAPI) {
-      try {
-        // Get all current elements and delete them from backend
-        const response = await fetch('/api/elements')
-        const result: ApiResponse = await response.json()
-
-        if (result.success && result.elements) {
-          const deletePromises = result.elements.map(element =>
-            fetch(`/api/elements/${element.id}`, { method: 'DELETE' })
-          )
-          await Promise.all(deletePromises)
-        }
-
-        // Clear the frontend canvas
-        applySceneUpdateWithoutAutoSync(excalidrawAPI, {
-          elements: [],
-          captureUpdate: CaptureUpdateAction.IMMEDIATELY
-        })
-      } catch (error) {
-        console.error('Error clearing canvas:', error)
-        // Still clear frontend even if backend fails
-        applySceneUpdateWithoutAutoSync(excalidrawAPI, {
-          elements: [],
-          captureUpdate: CaptureUpdateAction.IMMEDIATELY
-        })
-      }
+    if (!canSyncScene()) return
+    const generation = pauseSceneSync()
+    try {
+      const response = await fetch('/api/elements/clear', {
+        method: 'DELETE', signal: AbortSignal.timeout(10000)
+      })
+      if (!response.ok) throw new Error('Could not clear the saved canvas')
+      // The server broadcasts canvas_cleared. HTTP is a fallback when that
+      // message has not arrived; do not overwrite a newer WebSocket scene.
+      if (generation === sceneGenerationRef.current) await loadExistingElements()
+    } catch (error) {
+      failSceneLoad(error, generation)
     }
   }
 
@@ -935,8 +724,8 @@ function App(): JSX.Element {
           <div className="sync-controls">
             <button
               className={`btn-primary ${syncStatus === 'syncing' ? 'btn-loading' : ''}`}
-              onClick={syncToBackend}
-              disabled={syncStatus === 'syncing' || !excalidrawAPI}
+              onClick={() => void syncToBackend()}
+              disabled={syncStatus === 'syncing' || !excalidrawAPI || !isConnected || sceneLoadStatus !== 'ready'}
             >
               {syncStatus === 'syncing' && <span className="spinner"></span>}
               {syncStatus === 'syncing' ? 'Syncing...' : 'Sync to Backend'}
@@ -958,9 +747,20 @@ function App(): JSX.Element {
             </div>
           </div>
 
-          <button className="btn-secondary" onClick={clearCanvas}>Clear Canvas</button>
+          <button className="btn-secondary" onClick={clearCanvas} disabled={!isConnected || sceneLoadStatus !== 'ready'}>Clear Canvas</button>
         </div>
       </div>
+
+      {sceneLoadStatus !== 'ready' && (
+        <div className="scene-load-status" role={sceneLoadStatus === 'failed' ? 'alert' : 'status'}>
+          <span>{sceneLoadStatus === 'failed'
+            ? 'Canvas could not be loaded. Sync is paused to protect your saved scene.'
+            : 'Loading canvas. Sync is paused until the scene is ready.'}</span>
+          {sceneLoadStatus === 'failed' && (
+            <button className="btn-secondary" onClick={() => void loadExistingElements()}>Retry loading</button>
+          )}
+        </div>
+      )}
 
       {/* Canvas Container */}
       <div className="canvas-container">
@@ -974,6 +774,7 @@ function App(): JSX.Element {
           style={{ width: '100%', height: '100%' }}
         >
           <Excalidraw
+            viewModeEnabled={sceneLoadStatus !== 'ready'}
             excalidrawAPI={(api: ExcalidrawAPIRefValue) => setExcalidrawAPI(api)}
             onChange={(_elements, appState) => {
               if (appState?.theme && appState.theme !== theme) {

--- a/frontend/src/utils/mermaidConverter.ts
+++ b/frontend/src/utils/mermaidConverter.ts
@@ -1,6 +1,6 @@
 import { parseMermaidToExcalidraw, MermaidConfig } from '@excalidraw/mermaid-to-excalidraw';
-import type { ExcalidrawElement } from '@excalidraw/excalidraw/types/element/types';
-import type { BinaryFiles } from '@excalidraw/excalidraw/types/types';
+import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types';
+import type { BinaryFiles } from '@excalidraw/excalidraw/types';
 
 export interface MermaidConversionResult {
   elements: readonly ExcalidrawElement[];

--- a/frontend/src/utils/scene.ts
+++ b/frontend/src/utils/scene.ts
@@ -1,0 +1,333 @@
+import { convertToExcalidrawElements, restoreElements } from '@excalidraw/excalidraw'
+import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types'
+
+export interface ServerElement {
+  id: string;
+  type: string;
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+  backgroundColor?: string;
+  strokeColor?: string;
+  strokeWidth?: number;
+  roughness?: number;
+  opacity?: number;
+  text?: string;
+  fontSize?: number;
+  fontFamily?: string | number;
+  label?: {
+    text: string;
+  };
+  createdAt?: string;
+  updatedAt?: string;
+  version?: number;
+  syncedAt?: string;
+  source?: string;
+  syncTimestamp?: string;
+  boundElements?: readonly any[] | null;
+  containerId?: string | null;
+  locked?: boolean;
+  // Arrow element binding
+  start?: { id: string };
+  end?: { id: string };
+  strokeStyle?: string;
+  endArrowhead?: string;
+  startArrowhead?: string;
+  // Image element fields
+  fileId?: string;
+  status?: string;
+  scale?: [number, number];
+  angle?: number;
+  link?: string | null;
+  frameId?: string | null;
+  name?: string | null;
+}
+
+// Helper function to clean elements for Excalidraw
+export const cleanElementForExcalidraw = (element: ServerElement): Partial<ExcalidrawElement> => {
+  const {
+    createdAt,
+    updatedAt,
+    syncedAt,
+    source,
+    syncTimestamp,
+    ...cleanElement
+  } = element;
+  return cleanElement as Partial<ExcalidrawElement>;
+}
+
+// Helper function to validate and fix element binding data
+const validateAndFixBindings = (elements: Partial<ExcalidrawElement>[]): Partial<ExcalidrawElement>[] => {
+  const elementMap = new Map(elements.map(el => [el.id!, el]));
+
+  return elements.map(element => {
+    const fixedElement = { ...element };
+
+    // Validate and fix boundElements
+    if (fixedElement.boundElements) {
+      if (Array.isArray(fixedElement.boundElements)) {
+        fixedElement.boundElements = fixedElement.boundElements.filter((binding: any) => {
+          // Ensure binding has required properties
+          if (!binding || typeof binding !== 'object') return false;
+          if (!binding.id || !binding.type) return false;
+
+          // Ensure the referenced element exists
+          const referencedElement = elementMap.get(binding.id);
+          if (!referencedElement) return false;
+
+          // Validate binding type
+          if (!['text', 'arrow'].includes(binding.type)) return false;
+
+          return true;
+        });
+
+        // Remove boundElements if empty
+        if (fixedElement.boundElements.length === 0) {
+          fixedElement.boundElements = null;
+        }
+      } else {
+        // Invalid boundElements format, set to null
+        fixedElement.boundElements = null;
+      }
+    }
+
+    // Validate and fix containerId
+    if (fixedElement.type === 'text' && fixedElement.containerId) {
+      const containerElement = elementMap.get(fixedElement.containerId);
+      if (!containerElement) {
+        // Container doesn't exist, remove containerId
+        fixedElement.containerId = null;
+      }
+    }
+
+    return fixedElement;
+  });
+}
+
+const isImageElement = (element: Partial<ExcalidrawElement>): boolean => {
+  return element.type === 'image'
+}
+
+const isFreedrawElement = (element: Partial<ExcalidrawElement>): boolean => {
+  return element.type === 'freedraw'
+}
+
+const isShapeContainerType = (type: string | undefined): boolean => {
+  return type === 'rectangle' || type === 'ellipse' || type === 'diamond'
+}
+
+const recenterBoundShapeTextElements = (
+  elements: Partial<ExcalidrawElement>[]
+): Partial<ExcalidrawElement>[] => {
+  const elementMap = new Map(elements.map((el) => [el.id, el]))
+
+  return elements.map((element) => {
+    if (element.type !== 'text' || !element.containerId) {
+      return element
+    }
+
+    const textElement = element as ExcalidrawElement & { type: 'text'; containerId: string; autoResize?: boolean }
+    const container = elementMap.get(textElement.containerId) as (ExcalidrawElement & { x: number; y: number; width: number; height: number }) | undefined
+    if (!container || !isShapeContainerType(container.type)) {
+      return element
+    }
+
+    if (textElement.autoResize === false) {
+      return element
+    }
+
+    if (
+      typeof container.x !== 'number' ||
+      typeof container.y !== 'number' ||
+      typeof container.width !== 'number' ||
+      typeof container.height !== 'number' ||
+      typeof textElement.width !== 'number' ||
+      typeof textElement.height !== 'number'
+    ) {
+      return element
+    }
+
+    return {
+      ...element,
+      x: container.x + (container.width - textElement.width) / 2,
+      y: container.y + (container.height - textElement.height) / 2,
+    }
+  })
+}
+
+const normalizeImageElement = (element: Partial<ExcalidrawElement>): Partial<ExcalidrawElement> => {
+  const img = element as any
+  return {
+    ...img,
+    angle: img.angle || 0,
+    strokeColor: img.strokeColor || 'transparent',
+    backgroundColor: img.backgroundColor || 'transparent',
+    fillStyle: img.fillStyle || 'solid',
+    strokeWidth: img.strokeWidth || 1,
+    strokeStyle: img.strokeStyle || 'solid',
+    roughness: img.roughness ?? 0,
+    opacity: img.opacity ?? 100,
+    groupIds: img.groupIds || [],
+    roundness: null,
+    seed: img.seed || Math.floor(Math.random() * 1000000),
+    version: img.version || 1,
+    versionNonce: img.versionNonce || Math.floor(Math.random() * 1000000),
+    isDeleted: img.isDeleted ?? false,
+    boundElements: img.boundElements || null,
+    link: img.link || null,
+    locked: img.locked || false,
+    status: img.status || 'saved',
+    fileId: img.fileId,
+    scale: img.scale || [1, 1],
+  }
+}
+
+const normalizeFreedrawElement = (element: Partial<ExcalidrawElement>): Partial<ExcalidrawElement> => {
+  const freedraw = element as any
+  return {
+    ...freedraw,
+    angle: freedraw.angle || 0,
+    backgroundColor: freedraw.backgroundColor || 'transparent',
+    fillStyle: freedraw.fillStyle || 'solid',
+    strokeWidth: freedraw.strokeWidth || 1,
+    strokeStyle: freedraw.strokeStyle || 'solid',
+    roughness: freedraw.roughness ?? 1,
+    opacity: freedraw.opacity ?? 100,
+    groupIds: freedraw.groupIds || [],
+    roundness: null,
+    seed: freedraw.seed || Math.floor(Math.random() * 1000000),
+    version: freedraw.version || 1,
+    versionNonce: freedraw.versionNonce || Math.floor(Math.random() * 1000000),
+    isDeleted: freedraw.isDeleted ?? false,
+    boundElements: freedraw.boundElements || null,
+    link: freedraw.link || null,
+    locked: freedraw.locked || false,
+    points: freedraw.points || [],
+    pressures: freedraw.pressures || [],
+    simulatePressure: freedraw.simulatePressure ?? true,
+    lastCommittedPoint: freedraw.lastCommittedPoint || null,
+  }
+}
+
+// Helper: restore startBinding/endBinding/boundElements after convertToExcalidrawElements strips them
+const restoreBindings = (
+  convertedElements: readonly any[],
+  originalElements: Partial<ExcalidrawElement>[]
+): any[] => {
+  const originalMap = new Map<string, any>();
+  for (const el of originalElements) {
+    if (el.id) originalMap.set(el.id, el);
+  }
+
+  return convertedElements.map((el: any) => {
+    const orig = originalMap.get(el.id);
+    if (!orig) return el;
+
+    const patched = { ...el };
+
+    if (orig.startBinding && !el.startBinding) {
+      patched.startBinding = orig.startBinding;
+    }
+    if (orig.endBinding && !el.endBinding) {
+      patched.endBinding = orig.endBinding;
+    }
+    if (orig.boundElements && (!el.boundElements || el.boundElements.length === 0)) {
+      patched.boundElements = orig.boundElements;
+    }
+    if (orig.elbowed !== undefined && el.elbowed === undefined) {
+      patched.elbowed = orig.elbowed;
+    }
+
+    return patched;
+  });
+};
+
+const isFrame = (element: Partial<ExcalidrawElement>): element is Partial<Extract<ExcalidrawElement, { type: 'frame' | 'magicframe' }>> =>
+  element.type === 'frame' || element.type === 'magicframe'
+
+// A successful restore may still silently discard an unsupported or tiny
+// element. Never allow that partial scene to become a full-sync baseline.
+export const assertScenePreserved = (
+  expected: readonly Partial<ExcalidrawElement>[],
+  actual: readonly Partial<ExcalidrawElement>[]
+): void => {
+  const active = actual.filter(el => !el.isDeleted)
+  const actualById = new Map(active.map(el => [el.id, el]))
+  if (actualById.size !== active.length) throw new Error('Scene restore produced duplicate element IDs')
+  for (const element of expected) {
+    if (element.isDeleted) continue
+    const restored = actualById.get(element.id)
+    if (!restored || restored.type !== element.type) {
+      throw new Error(`Scene restore lost element ${element.id} (${element.type})`)
+    }
+    if ((element.frameId ?? null) !== (restored.frameId ?? null)) {
+      throw new Error(`Scene restore changed frame membership for ${element.id}`)
+    }
+    if (element.frameId && !isFrame(actualById.get(element.frameId) || {})) {
+      throw new Error(`Missing frame ${element.frameId} for ${element.id}`)
+    }
+    if (isFrame(element) && isFrame(restored)) {
+      for (const key of ['x', 'y', 'width', 'height', 'name'] as const) {
+        if (element[key] !== undefined && element[key] !== restored[key]) {
+          throw new Error(`Scene restore changed frame ${element.id}.${key}`)
+        }
+      }
+    }
+  }
+}
+
+export const prepareServerScene = (
+  elements: readonly Partial<ExcalidrawElement>[]
+): ExcalidrawElement[] => {
+  if (!Array.isArray(elements)) throw new Error('Expected a scene element array')
+  const ids = new Set<string>()
+  for (const element of elements) {
+    if (!element || typeof element.id !== 'string' || !element.id ||
+        typeof element.type !== 'string' || ids.has(element.id)) {
+      throw new Error('Scene contains an invalid or duplicate element ID')
+    }
+    ids.add(element.id)
+    if (!Number.isFinite(element.x) || !Number.isFinite(element.y) ||
+        (element.width !== undefined && !Number.isFinite(element.width)) ||
+        (element.height !== undefined && !Number.isFinite(element.height))) {
+      throw new Error(`Scene contains invalid coordinates for ${element.id}`)
+    }
+  }
+
+  const validated = validateAndFixBindings([...elements])
+  // Native frames express membership through the children's frameId. The
+  // skeleton converter instead requires frame.children and recalculates bounds.
+  const skeletons = validated.filter(el => !isFrame(el) && !isImageElement(el) && !isFreedrawElement(el))
+  const converted = restoreBindings(
+    convertToExcalidrawElements(skeletons as any, { regenerateIds: false }),
+    skeletons
+  )
+  const convertedById = new Map(converted.map(el => [el.id, el]))
+  const generatedText = new Map<string, ExcalidrawElement[]>()
+  for (const element of converted) {
+    if (!ids.has(element.id) && element.type === 'text' && element.containerId) {
+      const siblings = generatedText.get(element.containerId) || []
+      siblings.push(element)
+      generatedText.set(element.containerId, siblings)
+    }
+  }
+
+  // Preserve the original stacking order, including interleaved frames, images
+  // and freehand strokes. Newly expanded labels sit beside their container.
+  const ordered = validated.flatMap(element => {
+    const next = isFrame(element) ? element
+      : isImageElement(element) ? normalizeImageElement(element)
+      : isFreedrawElement(element) ? normalizeFreedrawElement(element)
+      : convertedById.get(element.id)
+    if (!next) throw new Error(`Scene conversion lost element ${element.id}`)
+    return [next, ...(generatedText.get(element.id!) || [])]
+  })
+  const restored = restoreElements(
+    recenterBoundShapeTextElements(ordered) as ExcalidrawElement[],
+    null,
+    { repairBindings: true }
+  )
+  assertScenePreserved(elements, restored)
+  return restored
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "mcp-excalidraw-server": "dist/bin.js"
       },
       "devDependencies": {
+        "@playwright/test": "^1.63.0",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/node": "^20.19.7",
@@ -1244,6 +1245,22 @@
       ],
       "engines": {
         "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -5900,6 +5917,35 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/png-chunk-text": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "test": "npm run test:mcp && npm run test:bind",
     "test:bind": "npm run build:server && node scripts/check-local-bind.mjs",
     "test:mcp": "npm run build:server && node scripts/check-mcp-stdio.mjs",
+    "test:canvas": "npm run build && playwright test",
+    "type-check:frontend": "tsc --noEmit -p frontend/tsconfig.json",
     "type-check": "npx tsc --noEmit"
   },
   "dependencies": {
@@ -43,6 +45,7 @@
     "zod-to-json-schema": "^3.22.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.63.0",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^20.19.7",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,27 @@
+import { defineConfig } from '@playwright/test';
+
+// Never attach these destructive fixture tests to an existing user's canvas.
+const port = Number(process.env.CANVAS_TEST_PORT || 51910);
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: './tests/browser',
+  workers: 1,
+  fullyParallel: false,
+  timeout: 30000,
+  expect: { timeout: 10000 },
+  use: {
+    baseURL,
+    browserName: 'chromium',
+    viewport: { width: 1280, height: 900 },
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  webServer: {
+    command: 'node dist/server.js',
+    env: { HOST: '127.0.0.1', PORT: String(port), LOG_LEVEL: 'error' },
+    url: `${baseURL}/health`,
+    reuseExistingServer: false,
+    timeout: 15000,
+  },
+});

--- a/tests/browser/fixtures.mjs
+++ b/tests/browser/fixtures.mjs
@@ -1,0 +1,44 @@
+// Issue #109's native frame shape: no skeleton-only `children` property.
+const base = {
+  x: 0, y: 0, width: 400, height: 300,
+  strokeColor: '#1971c2', backgroundColor: 'transparent', version: 1,
+  versionNonce: 1, isDeleted: false, groupIds: [], frameId: null, seed: 1,
+  updated: 1, angle: 0, fillStyle: 'solid', link: null, locked: false,
+  opacity: 100, roughness: 1, roundness: null, strokeStyle: 'solid', strokeWidth: 2,
+};
+
+export function frameScene() {
+  return [
+    { ...base, id: 'frame-repro-1', type: 'frame', name: 'repro-frame', index: 'a0' },
+    ...['Hello inside frame', 'Second text inside frame'].map((text, i) => ({
+      ...base, id: `text-repro-${i + 1}`, type: 'text', x: 20, y: 30 + 60 * i,
+      width: 220, height: 24, text, originalText: text, fontSize: 18, fontFamily: 5,
+      textAlign: 'left', verticalAlign: 'top', containerId: null, boundElements: null,
+      autoResize: true, lineHeight: 1.3, frameId: 'frame-repro-1', index: `a${i + 1}`,
+    })),
+  ];
+}
+
+export function mixedScene() {
+  return [
+    { ...base, id: 'shape', type: 'rectangle', x: 450, width: 140, height: 80,
+      boundElements: [{ id: 'label', type: 'text' }, { id: 'arrow', type: 'arrow' }] },
+    { ...base, id: 'label', type: 'text', text: 'Bound label', originalText: 'Bound label',
+      x: 460, y: 30, width: 120, height: 25, fontSize: 20, fontFamily: 5,
+      textAlign: 'center', verticalAlign: 'middle', containerId: 'shape', autoResize: false, lineHeight: 1.25 },
+    { ...base, id: 'image', type: 'image', x: 650, width: 30, height: 30,
+      fileId: 'pixel', status: 'saved', scale: [1, 1] },
+    ...frameScene(),
+    { ...base, id: 'freehand', type: 'freedraw', x: 500, y: 150, width: 40, height: 20,
+      points: [[0, 0], [20, 20], [40, 0]], pressures: [0.5, 0.5, 0.5], simulatePressure: false },
+    { ...base, id: 'arrow', type: 'arrow', x: 591, y: 40, width: 80, height: 0,
+      points: [[0, 0], [80, 0]], startBinding: { elementId: 'shape', focus: 0, gap: 1 },
+      endBinding: null, endArrowhead: 'arrow', startArrowhead: null },
+    { id: 'shorthand', type: 'rectangle', x: 450, y: 220, label: { text: 'Agent label' } },
+  ].map((element, i) => ({ ...element, index: `a${i}` }));
+}
+
+export const pixelFile = {
+  id: 'pixel', mimeType: 'image/png', created: 1,
+  dataURL: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jRZkAAAAASUVORK5CYII=',
+};

--- a/tests/browser/scene-reload.spec.mjs
+++ b/tests/browser/scene-reload.spec.mjs
@@ -1,0 +1,293 @@
+import { test, expect } from '@playwright/test';
+import { frameScene, mixedScene, pixelFile } from './fixtures.mjs';
+
+const syncButton = page => page.getByRole('button', { name: 'Sync to Backend', exact: true });
+const warning = page => page.getByRole('alert').filter({ hasText: 'Sync is paused' });
+
+async function serverScene(request) {
+  const response = await request.get('/api/elements');
+  expect(response.ok()).toBeTruthy();
+  return (await response.json()).elements;
+}
+
+async function seed(request, elements) {
+  const response = await request.post('/api/elements/sync', { data: { elements } });
+  expect(response.ok()).toBeTruthy();
+}
+
+async function sync(page, request) {
+  await expect(syncButton(page)).toBeEnabled();
+  const completed = page.waitForResponse(r => r.url().endsWith('/api/elements/sync') && r.request().method() === 'POST');
+  await syncButton(page).click();
+  expect((await completed).ok()).toBeTruthy();
+  return serverScene(request);
+}
+
+function expectFrame(elements) {
+  expect(elements.find(e => e.id === 'frame-repro-1')).toMatchObject({
+    type: 'frame', name: 'repro-frame', x: 0, y: 0, width: 400, height: 300,
+  });
+  for (const id of ['text-repro-1', 'text-repro-2']) {
+    expect(elements.find(e => e.id === id)).toMatchObject({ type: 'text', frameId: 'frame-repro-1' });
+  }
+}
+
+// Use the real backend except where a specific corrupt/delayed wire message is
+// injected. No Excalidraw mocks or production-only test API are involved.
+async function interceptSocket(page, { forwardInitial = true } = {}) {
+  let client;
+  let upstream;
+  await page.routeWebSocket('**', socket => {
+    client = socket;
+    upstream = socket.connectToServer();
+    upstream.onMessage(message => {
+      if (!forwardInitial && JSON.parse(String(message)).type === 'initial_elements') return;
+      socket.send(message);
+    });
+  });
+  return {
+    send: message => client.send(JSON.stringify(message)),
+    reconnect: () => {
+      upstream.close();
+      client.close({ code: 1012, reason: 'test reconnect' });
+    },
+  };
+}
+
+test.beforeEach(async ({ request }) => {
+  await seed(request, []);
+});
+
+test('native frame survives real WebSocket load, repeated reload and sync', async ({ page, request }) => {
+  await seed(request, frameScene());
+  await page.goto('/');
+  for (let i = 0; i < 3; i++) {
+    await expect(page.getByText('repro-frame', { exact: true })).toBeVisible();
+    const scene = await sync(page, request);
+    expect(scene).toHaveLength(3);
+    expectFrame(scene);
+    if (i < 2) await page.reload();
+  }
+});
+
+test('HTTP fallback restores frames when the initial WebSocket scene is missed', async ({ page, request }) => {
+  await seed(request, frameScene());
+  await interceptSocket(page, { forwardInitial: false });
+  await page.goto('/');
+  expectFrame(await sync(page, request));
+});
+
+test('a frame drawn with the UI survives sync, reload and another edit', async ({ page, request }) => {
+  await page.goto('/');
+  await expect(syncButton(page)).toBeEnabled();
+  await page.mouse.click(850, 650); // keyboard shortcuts are scoped to the editor
+  await page.keyboard.press('f');
+  await page.mouse.move(350, 250);
+  await page.mouse.down();
+  await page.mouse.move(750, 550, { steps: 8 });
+  await page.mouse.up();
+  const original = await sync(page, request);
+  const frame = original.find(e => e.type === 'frame');
+  expect(frame).toBeDefined();
+  await page.reload();
+  await expect(syncButton(page)).toBeEnabled();
+  await page.mouse.click(850, 650);
+  await page.keyboard.press('r');
+  await expect(page.getByRole('radio', { name: 'Rectangle', exact: true })).toBeChecked();
+  await page.mouse.move(450, 350);
+  await page.mouse.down();
+  await page.mouse.move(550, 450, { steps: 5 });
+  await page.mouse.up();
+  const result = await sync(page, request);
+  expect(result.find(e => e.id === frame.id)).toMatchObject({
+    type: 'frame', x: frame.x, y: frame.y, width: frame.width, height: frame.height,
+  });
+  expect(result.some(e => e.type === 'rectangle' && e.frameId === frame.id)).toBeTruthy();
+});
+
+test('reconnect and server incremental updates preserve an existing frame', async ({ page, request }) => {
+  await seed(request, frameScene());
+  const socket = await interceptSocket(page);
+  await page.goto('/');
+  await expect(syncButton(page)).toBeEnabled();
+  socket.reconnect();
+  await expect(page.getByText('Disconnected', { exact: true })).toBeVisible();
+  await expect(syncButton(page)).toBeDisabled();
+  await expect(syncButton(page)).toBeEnabled({ timeout: 15000 });
+  const created = await request.post('/api/elements', {
+    data: { id: 'server-added', type: 'rectangle', x: 500, y: 350, width: 120, height: 80 },
+  });
+  expect(created.ok()).toBeTruthy();
+  // Allow the WebSocket event to run before sending a full-scene writeback.
+  await page.waitForTimeout(150);
+  expect((await sync(page, request)).map(e => e.id)).toContain('server-added');
+  expectFrame(await serverScene(request));
+});
+
+test('successful Mermaid import and SVG export retain the frame scene', async ({ page, request }) => {
+  await seed(request, frameScene());
+  await page.goto('/');
+  await expect(syncButton(page)).toBeEnabled();
+  const completion = page.waitForResponse(r => r.url().endsWith('/api/elements/sync') && r.request().method() === 'POST');
+  const imported = await request.post('/api/elements/from-mermaid', { data: { mermaidDiagram: 'flowchart LR; A[One]-->B[Two]' } });
+  expect(imported.ok()).toBeTruthy();
+  expect((await completion).ok()).toBeTruthy();
+  const scene = await serverScene(request);
+  expectFrame(scene);
+  expect(scene.length).toBeGreaterThan(3);
+  const exported = await request.post('/api/export/image', { data: { format: 'svg' } });
+  expect(exported.ok()).toBeTruthy();
+  const result = await exported.json();
+  expect(result.data).toContain('<svg');
+  expect(result.data).toContain('Hello inside frame');
+  expectFrame(await serverScene(request));
+});
+
+test('HTTP failure pauses sync and a successful retry recovers the scene', async ({ page, request }) => {
+  await seed(request, frameScene());
+  await interceptSocket(page, { forwardInitial: false });
+  await page.route('**/api/elements', route => route.fulfill({ status: 503, json: { success: false } }));
+  await page.goto('/');
+  await expect(warning(page)).toBeVisible();
+  await expect(syncButton(page)).toBeDisabled();
+  await page.unroute('**/api/elements');
+  await page.getByRole('button', { name: 'Retry loading' }).click();
+  expectFrame(await sync(page, request));
+});
+
+test('mixed native elements retain stacking order, bindings and shorthand labels', async ({ page, request }) => {
+  await request.post('/api/files', { data: { files: [pixelFile] } });
+  const original = mixedScene();
+  await seed(request, original);
+  await page.goto('/');
+  const result = await sync(page, request);
+  expectFrame(result);
+  expect(result.filter(e => original.some(source => source.id === e.id)).map(e => e.id))
+    .toEqual(original.map(e => e.id));
+  expect(result.find(e => e.id === 'label').containerId).toBe('shape');
+  expect(result.find(e => e.id === 'arrow').startBinding.elementId).toBe('shape');
+  expect(result.find(e => e.id === 'image').fileId).toBe('pixel');
+  expect(result.find(e => e.id === 'freehand').points).toEqual([[0, 0], [20, 20], [40, 0]]);
+  expect(result.some(e => e.type === 'text' && e.text === 'Agent label' && e.containerId === 'shorthand')).toBeTruthy();
+});
+
+for (const [name, badElement] of [
+  ['unknown element type', { id: 'bad', type: 'future-element', x: 0, y: 0, width: 100, height: 100 }],
+  ['silently filtered tiny frame', { id: 'bad', type: 'frame', x: 0, y: 0, width: 0, height: 0 }],
+]) {
+  test(`${name} blocks manual, automatic and Mermaid sync without changing server data`, async ({ page, request }) => {
+    await seed(request, [...frameScene(), badElement]);
+    const before = await serverScene(request);
+    const writes = [];
+    page.on('request', r => {
+      if (r.method() === 'POST' && r.url().endsWith('/api/elements/sync')) writes.push(r);
+    });
+    await page.goto('/');
+    await expect(warning(page)).toBeVisible();
+    await expect(syncButton(page)).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Clear Canvas', exact: true })).toBeDisabled();
+    await page.mouse.click(500, 400);
+    await page.keyboard.press('Delete');
+    await request.post('/api/elements/from-mermaid', { data: { mermaidDiagram: 'flowchart LR; A-->B' } });
+    await page.waitForTimeout(1600); // cover the actual 1200 ms autosync debounce
+    expect(writes).toHaveLength(0);
+    expect(await serverScene(request)).toEqual(before);
+    await seed(request, frameScene());
+    await page.getByRole('button', { name: 'Retry loading' }).click();
+    expectFrame(await sync(page, request));
+  });
+}
+
+test('failed remote restore preserves visible scene and cancels a pending autosync', async ({ page, request }) => {
+  await seed(request, frameScene());
+  const socket = await interceptSocket(page);
+  await page.goto('/');
+  await expect(syncButton(page)).toBeEnabled();
+  const before = await serverScene(request);
+  const writes = [];
+  page.on('request', r => {
+    if (r.method() === 'POST' && r.url().endsWith('/api/elements/sync')) writes.push(r);
+  });
+  await page.mouse.click(850, 650);
+  await page.keyboard.press('r');
+  await expect(page.getByRole('radio', { name: 'Rectangle', exact: true })).toBeChecked();
+  await page.mouse.move(750, 450);
+  await page.mouse.down();
+  await page.mouse.move(850, 550, { steps: 5 });
+  await page.mouse.up();
+  socket.send({ type: 'initial_elements', elements: [...frameScene(), { id: 'broken', type: 'frame', x: null, y: 0 }] });
+  await expect(warning(page)).toBeVisible();
+  await expect(page.getByText('repro-frame', { exact: true })).toBeVisible();
+  await page.waitForTimeout(1600);
+  expect(writes).toHaveLength(0);
+  expect(await serverScene(request)).toEqual(before);
+});
+
+test('an older HTTP success cannot unlock sync after a newer WebSocket failure', async ({ page, request }) => {
+  await seed(request, frameScene());
+  const socket = await interceptSocket(page, { forwardInitial: false });
+  const pending = [];
+  await page.route('**/api/elements', route => pending.push(route));
+  await page.goto('/');
+  await expect.poll(() => pending.length).toBeGreaterThan(0);
+  socket.send({ type: 'initial_elements', elements: [{ id: 'bad', type: 'frame', x: 0, y: 0, width: 0, height: 0 }] });
+  await expect(warning(page)).toBeVisible();
+  for (const route of pending) await route.fulfill({ json: { success: true, elements: frameScene() } });
+  await page.waitForTimeout(300);
+  await expect(warning(page)).toBeVisible();
+  await expect(syncButton(page)).toBeDisabled();
+  expectFrame(await serverScene(request));
+});
+
+test('a newer empty WebSocket scene wins over an older HTTP scene', async ({ page, request }) => {
+  await seed(request, frameScene());
+  const socket = await interceptSocket(page, { forwardInitial: false });
+  const pending = [];
+  await page.route('**/api/elements', route => pending.push(route));
+  await page.goto('/');
+  await expect.poll(() => pending.length).toBeGreaterThan(0);
+  await seed(request, []);
+  socket.send({ type: 'initial_elements', elements: [] });
+  await expect(syncButton(page)).toBeEnabled();
+  for (const route of pending) await route.fulfill({ json: { success: true, elements: frameScene() } });
+  await page.waitForTimeout(300);
+  expect(await sync(page, request)).toEqual([]);
+});
+
+test('explicit clear succeeds after loading and remains empty on reload', async ({ page, request }) => {
+  await seed(request, frameScene());
+  await page.goto('/');
+  await expect(syncButton(page)).toBeEnabled();
+  await page.getByRole('button', { name: 'Clear Canvas', exact: true }).click();
+  await expect.poll(() => serverScene(request)).toEqual([]);
+  await page.reload();
+  expect(await sync(page, request)).toEqual([]);
+});
+
+test('normal select-all deletion can still autosync an empty scene', async ({ page, request }) => {
+  await seed(request, frameScene());
+  await page.goto('/');
+  await expect(syncButton(page)).toBeEnabled();
+  await page.mouse.click(850, 650);
+  await page.keyboard.press('v');
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.press('Delete');
+  // Excalidraw deletes the selected frame first and selects its remaining
+  // children. A second Delete removes those children as well.
+  await page.keyboard.press('Delete');
+  await expect.poll(() => serverScene(request)).toEqual([]);
+  await page.reload();
+  expect(await sync(page, request)).toEqual([]);
+});
+
+test('failed clear keeps the visible and saved scene protected', async ({ page, request }) => {
+  await seed(request, frameScene());
+  await page.goto('/');
+  await expect(syncButton(page)).toBeEnabled();
+  const before = await serverScene(request);
+  await page.route('**/api/elements/clear', route => route.fulfill({ status: 503, json: { error: 'unavailable' } }));
+  await page.getByRole('button', { name: 'Clear Canvas', exact: true }).click();
+  await expect(warning(page)).toBeVisible();
+  await expect(page.getByText('repro-frame', { exact: true })).toBeVisible();
+  expect(await serverScene(request)).toEqual(before);
+});


### PR DESCRIPTION
Fixes #109.

Reloading a saved native frame sent it through Excalidraw's skeleton converter, which expects `frame.children`. Native scenes store membership on each child's `frameId`, so conversion threw and left an empty canvas that could subsequently overwrite the saved scene.

Frames now bypass skeleton conversion and are restored with the complete scene, preserving frame geometry, names, membership, and element order. Scene preparation and API readback check for missing elements; failed loads retain the visible scene and pause manual, automatic, and Mermaid-triggered sync until a successful reload. Load generations reject stale HTTP responses after newer WebSocket updates. Clearing uses the existing server clear endpoint and retains the visible scene on failure.

Adds a dedicated Chromium regression suite and frontend type checking to CI. This change does not introduce server revision/CAS or change the full-sync protocol; concurrent-client conflict protection remains separate work.

Validation completed locally against the production build and an isolated localhost server:

- 15 Chromium browser tests passed: frame creation/reload/reconnect, HTTP fallback, mixed elements and bindings, failed-load protection, queued autosync cancellation, stale response handling, normal deletion/clear, Mermaid import, and SVG export.
- `npm run build`
- `npm run type-check` and `npm run type-check:frontend`
- `npm test` (MCP stdio and local-bind regression checks)
- `git diff --check`
- Visual inspection of the restored frame; no unhandled browser errors.
